### PR TITLE
Remove unused Rx dependency

### DIFF
--- a/UaClient.UnitTests/Workstation.UaClient.UnitTests.csproj
+++ b/UaClient.UnitTests/Workstation.UaClient.UnitTests.csproj
@@ -31,6 +31,7 @@
     <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="2.0.0" />
     <PackageReference Include="MSTest.TestAdapter" Version="1.1.18" />
     <PackageReference Include="MSTest.TestFramework" Version="1.1.18" />
+    <PackageReference Include="System.Reactive" Version="3.1.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/UaClient/Workstation.UaClient.csproj
+++ b/UaClient/Workstation.UaClient.csproj
@@ -30,7 +30,6 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.IO.RecyclableMemoryStream" Version="1.2.2" />
     <PackageReference Include="Portable.BouncyCastle" Version="1.8.1.3" />
-    <PackageReference Include="System.Reactive" Version="3.1.1" />
     <PackageReference Include="System.Threading.Tasks.Dataflow" Version="4.8.0" />
     <PackageReference Include="System.ValueTuple" Version="4.4.0" />
   </ItemGroup>


### PR DESCRIPTION
While I really like Rx, it is not used in the `opc-ua-client` library. Hence this dependency can be removed.