### PR TITLE
There is no read access to the `closedCalled` variable -> remove it

### DIFF
--- a/UaClient/ServiceModel/Ua/Channels/CommunicationObject.cs
+++ b/UaClient/ServiceModel/Ua/Channels/CommunicationObject.cs
@@ -16,7 +16,6 @@ namespace Workstation.ServiceModel.Ua.Channels
     {
         private readonly ILogger logger;
         private bool aborted;
-        private bool closeCalled;
         private bool onClosingCalled;
         private bool onClosedCalled;
         private bool onOpeningCalled;
@@ -119,8 +118,6 @@ namespace Workstation.ServiceModel.Ua.Channels
                 {
                     this.State = CommunicationState.Closing;
                 }
-
-                this.closeCalled = true;
             }
             finally
             {


### PR DESCRIPTION
This causes a [CS0414](https://docs.microsoft.com/en-us/dotnet/csharp/misc/cs0414) warning.