### PR TITLE
Add a github workflow to automatically run the unit tests

### DIFF
--- a/.github/workflows/unittests.yml
+++ b/.github/workflows/unittests.yml
@@ -1,0 +1,19 @@
+name: Unit Tests
+
+on: [pull_request, push]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+    
+    steps:
+    - uses: actions/checkout@v1
+    - name: Setup .NET Core
+      uses: actions/setup-dotnet@v1
+      with:
+        dotnet-version: 2.2.108
+    - name: Build with dotnet
+      run: dotnet build --configuration Release
+    - name: Run unit tests
+      run: dotnet test --filter "FullyQualifiedName~UnitTests" 

--- a/UaClient.UnitTests/Workstation.UaClient.UnitTests.csproj
+++ b/UaClient.UnitTests/Workstation.UaClient.UnitTests.csproj
@@ -1,13 +1,14 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net461</TargetFramework>
+    <TargetFramework>netcoreapp2.0</TargetFramework>
     <AssemblyName>Workstation.UaClient.UnitTests</AssemblyName>
     <RootNamespace>Workstation.UaClient</RootNamespace>
     <Version>2.0.0</Version>
     <AssemblyVersion>2.0.0.0</AssemblyVersion>
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
     <GenerateBindingRedirectsOutputType>true</GenerateBindingRedirectsOutputType>
+    <LangVersion>latest</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/UaClient/Workstation.UaClient.csproj
+++ b/UaClient/Workstation.UaClient.csproj
@@ -22,6 +22,7 @@
     <IncludeSymbols>true</IncludeSymbols>
     <GenerateDocumentationFile Condition=" '$(Configuration)' == 'Release' ">true</GenerateDocumentationFile>
     <PackageLicenseFile>LICENSE.txt</PackageLicenseFile>
+    <LangVersion>latest</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
This PR adds an github workflow that will automatically run the unit tests after a push to the repository and after a pull request. That way you always know that a change will not break compilation and one of the unit tests. Since the test run on a ubuntu machine, I had to change the unit tests to be a dotnet core library instead of .net framework. Futhermore I had to change the language from _default_ to _latest_. I guess on the test machine _default_ is interpreted as _latest major version_ (that is 7), but the code use 7.1 or 7.2 language features.

[Github actions](https://github.com/features/actions) are still in a semi public beta phase and will go public in November. So propbably the workflow will not run in your repository atm. You can of course, also sign up to participate on the beta. If you are interested in how that will look like in action, you can take a look my repository:

![grafik](https://user-images.githubusercontent.com/5264714/65120691-500d3f00-d9ee-11e9-827f-2a06bd3634cf.png)

The green check and the red cross signal if everything went well or some problem occured. Here I had to change the language version, else the library and the tests wouldn't compile.