### PR TITLE
exception when not anonymous and no user/pass

### DIFF
--- a/UaClient/ServiceModel/Ua/Channels/UaTcpSessionChannel.cs
+++ b/UaClient/ServiceModel/Ua/Channels/UaTcpSessionChannel.cs
@@ -589,12 +589,15 @@ namespace Workstation.ServiceModel.Ua.Channels
                 }
 
                 var userNameIdentity = (UserNameIdentity)this.UserIdentity;
-                if (userNameIdentity.UserName == null || userNameIdentity.Password == null)
+
+                // if username and password are empty and there is no anonymous token
+                if (userNameIdentity.UserName == null && userNameIdentity.Password == null
+                    && this.RemoteEndpoint.UserIdentityTokens.FirstOrDefault(t => t.TokenType == UserTokenType.Anonymous) == null)
                 {
                     throw new InvalidOperationException("Authentication is not anonymous, but no username and password were provided.");
                 }
 
-                byte[] passwordBytes = System.Text.Encoding.UTF8.GetBytes(userNameIdentity.Password);
+                byte[] passwordBytes = userNameIdentity.Password != null ? System.Text.Encoding.UTF8.GetBytes(userNameIdentity.Password) : new byte[0];
                 int plainTextLength = passwordBytes.Length + this.RemoteNonce.Length;
                 IBufferedCipher encryptor;
                 byte[] cipherText;

--- a/UaClient/ServiceModel/Ua/Channels/UaTcpSessionChannel.cs
+++ b/UaClient/ServiceModel/Ua/Channels/UaTcpSessionChannel.cs
@@ -589,14 +589,6 @@ namespace Workstation.ServiceModel.Ua.Channels
                 }
 
                 var userNameIdentity = (UserNameIdentity)this.UserIdentity;
-
-                // if username and password are empty and there is no anonymous token
-                if (userNameIdentity.UserName == null && userNameIdentity.Password == null
-                    && this.RemoteEndpoint.UserIdentityTokens.FirstOrDefault(t => t.TokenType == UserTokenType.Anonymous) == null)
-                {
-                    throw new InvalidOperationException("Authentication is not anonymous, but no username and password were provided.");
-                }
-
                 byte[] passwordBytes = userNameIdentity.Password != null ? System.Text.Encoding.UTF8.GetBytes(userNameIdentity.Password) : new byte[0];
                 int plainTextLength = passwordBytes.Length + this.RemoteNonce.Length;
                 IBufferedCipher encryptor;

--- a/UaClient/ServiceModel/Ua/Channels/UaTcpSessionChannel.cs
+++ b/UaClient/ServiceModel/Ua/Channels/UaTcpSessionChannel.cs
@@ -589,9 +589,9 @@ namespace Workstation.ServiceModel.Ua.Channels
                 }
 
                 var userNameIdentity = (UserNameIdentity)this.UserIdentity;
-                if (userNameIdentity.UserName == null && userNameIdentity.Password == null)
+                if (userNameIdentity.UserName == null || userNameIdentity.Password == null)
                 {
-                    throw new Exception("Authentication is not anonymous, but no username and password were provided.");
+                    throw new InvalidOperationException("Authentication is not anonymous, but no username and password were provided.");
                 }
 
                 byte[] passwordBytes = System.Text.Encoding.UTF8.GetBytes(userNameIdentity.Password);

--- a/UaClient/ServiceModel/Ua/Channels/UaTcpSessionChannel.cs
+++ b/UaClient/ServiceModel/Ua/Channels/UaTcpSessionChannel.cs
@@ -589,6 +589,11 @@ namespace Workstation.ServiceModel.Ua.Channels
                 }
 
                 var userNameIdentity = (UserNameIdentity)this.UserIdentity;
+                if (userNameIdentity.UserName == null && userNameIdentity.Password == null)
+                {
+                    throw new Exception("Authentication is not anonymous, but no username and password were provided.");
+                }
+
                 byte[] passwordBytes = System.Text.Encoding.UTF8.GetBytes(userNameIdentity.Password);
                 int plainTextLength = passwordBytes.Length + this.RemoteNonce.Length;
                 IBufferedCipher encryptor;


### PR DESCRIPTION
When the OPC UA server does not have anonymous authentication enabled and no username and password are provided, you get the following error:

> System.ArgumentNullException: 'String reference not set to an instance of a String.
> Parameter name: s'

at line 592 of UaTcpSessionChannel.cs

```
var userNameIdentity = (UserNameIdentity)this.UserIdentity;
byte[] passwordBytes = System.Text.Encoding.UTF8.GetBytes(userNameIdentity.Password);
```

because the password is null.

This change throws an exception that is more clear. Let me know if I should change the Exception message or Exception class.

Thanks
