### PR TITLE
Use readonly when possible

### DIFF
--- a/UaClient/Collections/ObservableQueue.cs
+++ b/UaClient/Collections/ObservableQueue.cs
@@ -13,8 +13,8 @@ namespace Workstation.Collections
     /// <typeparam name="T">Type of element.</typeparam>
     public class ObservableQueue<T> : Queue<T>, INotifyCollectionChanged, INotifyPropertyChanged
     {
-        private int capacity;
-        private bool isFixedSize;
+        private readonly int capacity;
+        private readonly bool isFixedSize;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="ObservableQueue{T}"/> class.

--- a/UaClient/ServiceModel/Ua/Channels/BinaryDecoder.cs
+++ b/UaClient/ServiceModel/Ua/Channels/BinaryDecoder.cs
@@ -14,10 +14,10 @@ namespace Workstation.ServiceModel.Ua.Channels
     {
         private const long MinFileTime =  504911232000000000L;
         private const long MaxFileTime = 3155378975990000000L;
-        private Stream stream;
-        private UaTcpSecureChannel channel;
-        private Encoding encoding;
-        private BinaryReader reader;
+        private readonly Stream stream;
+        private readonly UaTcpSecureChannel channel;
+        private readonly Encoding encoding;
+        private readonly BinaryReader reader;
 
         public BinaryDecoder(Stream stream, UaTcpSecureChannel channel = null, bool keepStreamOpen = false)
         {

--- a/UaClient/ServiceModel/Ua/Channels/BinaryEncoder.cs
+++ b/UaClient/ServiceModel/Ua/Channels/BinaryEncoder.cs
@@ -14,10 +14,10 @@ namespace Workstation.ServiceModel.Ua.Channels
     public sealed class BinaryEncoder : IEncoder, IDisposable
     {
         private const long MinFileTime = 504911232000000000L;
-        private Stream stream;
-        private UaTcpSecureChannel channel;
-        private Encoding encoding;
-        private BinaryWriter writer;
+        private readonly Stream stream;
+        private readonly UaTcpSecureChannel channel;
+        private readonly Encoding encoding;
+        private readonly BinaryWriter writer;
 
         public BinaryEncoder(Stream stream, UaTcpSecureChannel channel = null, bool keepStreamOpen = false)
         {

--- a/UaClient/ServiceModel/Ua/Channels/CommunicationObject.cs
+++ b/UaClient/ServiceModel/Ua/Channels/CommunicationObject.cs
@@ -23,8 +23,8 @@ namespace Workstation.ServiceModel.Ua.Channels
         private bool raisedClosed;
         private bool raisedClosing;
         private bool raisedFaulted;
-        private SemaphoreSlim semaphore;
-        private Lazy<ConcurrentQueue<Exception>> exceptions;
+        private readonly SemaphoreSlim semaphore;
+        private readonly Lazy<ConcurrentQueue<Exception>> exceptions;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="CommunicationObject"/> class.

--- a/UaClient/ServiceModel/Ua/Channels/UaTcpSessionChannel.cs
+++ b/UaClient/ServiceModel/Ua/Channels/UaTcpSessionChannel.cs
@@ -48,7 +48,7 @@ namespace Workstation.ServiceModel.Ua.Channels
         private readonly BroadcastBlock<PublishResponse> publishResponses;
         private readonly ActionBlock<PublishResponse> actionBlock;
         private readonly UaTcpSessionChannelOptions options;
-        private CancellationTokenSource stateMachineCts;
+        private readonly CancellationTokenSource stateMachineCts;
         private Task stateMachineTask;
 
         /// <summary>

--- a/UaClient/ServiceModel/Ua/DirectoryStore.cs
+++ b/UaClient/ServiceModel/Ua/DirectoryStore.cs
@@ -27,8 +27,8 @@ namespace Workstation.ServiceModel.Ua
     public class DirectoryStore : ICertificateStore
     {
         private readonly string pkiPath;
-        private X509CertificateParser certParser = new X509CertificateParser();
-        private SecureRandom rng = new SecureRandom();
+        private readonly X509CertificateParser certParser = new X509CertificateParser();
+        private readonly SecureRandom rng = new SecureRandom();
 
         /// <summary>
         /// Initializes a new instance of the <see cref="DirectoryStore"/> class.

--- a/UaClient/ServiceModel/Ua/MonitoredItemCollection.cs
+++ b/UaClient/ServiceModel/Ua/MonitoredItemCollection.cs
@@ -12,8 +12,8 @@ namespace Workstation.ServiceModel.Ua
     /// </summary>
     public class MonitoredItemBaseCollection : ObservableCollection<MonitoredItemBase>
     {
-        private Dictionary<string, MonitoredItemBase> nameMap = new Dictionary<string, MonitoredItemBase>();
-        private Dictionary<uint, MonitoredItemBase> clientIdMap = new Dictionary<uint, MonitoredItemBase>();
+        private readonly Dictionary<string, MonitoredItemBase> nameMap = new Dictionary<string, MonitoredItemBase>();
+        private readonly Dictionary<uint, MonitoredItemBase> clientIdMap = new Dictionary<uint, MonitoredItemBase>();
 
         /// <summary>
         /// Initializes a new instance of the <see cref="MonitoredItemBaseCollection"/> class.

--- a/UaClient/ServiceModel/Ua/SubscriptionBase.cs
+++ b/UaClient/ServiceModel/Ua/SubscriptionBase.cs
@@ -29,18 +29,18 @@ namespace Workstation.ServiceModel.Ua
         private volatile bool isPublishing;
         private volatile UaTcpSessionChannel innerChannel;
         private volatile uint subscriptionId;
-        private ErrorsContainer<string> errors;
+        private readonly ErrorsContainer<string> errors;
         private PropertyChangedEventHandler propertyChanged;
-        private string endpointUrl;
-        private double publishingInterval = UaTcpSessionChannel.DefaultPublishingInterval;
-        private uint keepAliveCount = UaTcpSessionChannel.DefaultKeepaliveCount;
-        private uint lifetimeCount;
-        private MonitoredItemBaseCollection monitoredItems = new MonitoredItemBaseCollection();
+        private readonly string endpointUrl;
+        private readonly double publishingInterval = UaTcpSessionChannel.DefaultPublishingInterval;
+        private readonly uint keepAliveCount = UaTcpSessionChannel.DefaultKeepaliveCount;
+        private readonly uint lifetimeCount;
+        private readonly MonitoredItemBaseCollection monitoredItems = new MonitoredItemBaseCollection();
         private CommunicationState state = CommunicationState.Created;
         private volatile TaskCompletionSource<bool> whenSubscribed;
         private volatile TaskCompletionSource<bool> whenUnsubscribed;
-        private CancellationTokenSource stateMachineCts;
-        private Task stateMachineTask;
+        private readonly CancellationTokenSource stateMachineCts;
+        private readonly Task stateMachineTask;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="SubscriptionBase"/> class.

--- a/UaClient/ServiceModel/Ua/Variant.cs
+++ b/UaClient/ServiceModel/Ua/Variant.cs
@@ -42,9 +42,9 @@ namespace Workstation.ServiceModel.Ua
 
     public struct Variant
     {
-        public static Variant Null = default(Variant);
+        public static readonly Variant Null = default(Variant);
 
-        private static Dictionary<Type, VariantType> typeMap = new Dictionary<Type, VariantType>()
+        private static readonly Dictionary<Type, VariantType> typeMap = new Dictionary<Type, VariantType>()
         {
             [typeof(bool)] = VariantType.Boolean,
             [typeof(sbyte)] = VariantType.SByte,
@@ -75,7 +75,7 @@ namespace Workstation.ServiceModel.Ua
             */
         };
 
-        private static Dictionary<Type, VariantType> elemTypeMap = new Dictionary<Type, VariantType>()
+        private static readonly Dictionary<Type, VariantType> elemTypeMap = new Dictionary<Type, VariantType>()
         {
             [typeof(bool)] = VariantType.Boolean,
             [typeof(sbyte)] = VariantType.SByte,


### PR DESCRIPTION
Here I add `readonly` to some private fields. This change should be safe as long as it compiles.