### PR TITLE
Increase code coverage of the binary encoder and decoder tests

### DIFF
--- a/UaClient.UnitTests/UnitTests/Channels/BinaryDecoderTests.Equivalency.cs
+++ b/UaClient.UnitTests/UnitTests/Channels/BinaryDecoderTests.Equivalency.cs
@@ -151,6 +151,16 @@ namespace Workstation.UaClient.UnitTests.Channels
             }
         }
 
+        private class MatrixEquivalency : TypeMappingEquivalency<Array, Opc.Ua.Matrix>
+        {
+            protected override void Test(Array subject, Opc.Ua.Matrix expectation, string because, object[] becauseArgs)
+            {
+                var arr = expectation.ToArray();
+                subject
+                    .Should().BeEquivalentTo(arr);
+            }
+        }
+
         private class XmlEquivalency : TypeMappingEquivalency<XElement, XmlElement>
         {
             protected override void Test(XElement subject, XmlElement expectation, string because, object[] becauseArgs)
@@ -206,6 +216,9 @@ namespace Workstation.UaClient.UnitTests.Channels
 
             // TimeZoneDataType
             AssertionOptions.AssertEquivalencyUsing(options => options.ComparingByMembers<TimeZoneDataType>().ExcludingMissingMembers());
+            
+            // Matrix/Multidim array
+            AssertionOptions.AssertEquivalencyUsing(options => options.Using(new MatrixEquivalency()));
         }
     }
 }

--- a/UaClient.UnitTests/UnitTests/Channels/BinaryDecoderTests.cs
+++ b/UaClient.UnitTests/UnitTests/Channels/BinaryDecoderTests.cs
@@ -19,12 +19,9 @@ namespace Workstation.UaClient.UnitTests.Channels
         private static T EncodeDecode<T>(Action<Opc.Ua.BinaryEncoder> encode, Func<BinaryDecoder, T> decode)
         {
             using (var stream = new MemoryStream())
+            using (var encoder = new Opc.Ua.BinaryEncoder(stream, new Opc.Ua.ServiceMessageContext {}))
+            using (var decoder = new BinaryDecoder(stream))
             {
-                var encoder = new Opc.Ua.BinaryEncoder(stream, new Opc.Ua.ServiceMessageContext
-                {
-
-                });
-                var decoder = new BinaryDecoder(stream);
 
                 encode(encoder);
                 stream.Position = 0;
@@ -37,6 +34,15 @@ namespace Workstation.UaClient.UnitTests.Channels
             XmlDocument doc = new XmlDocument();
             doc.LoadXml(xml);
             return doc.DocumentElement;
+        }
+
+        [Fact]
+        public void CreateWithNullStream()
+        {
+            Stream stream = null;
+
+            stream.Invoking(s => new BinaryDecoder(s))
+                .Should().Throw<ArgumentNullException>();
         }
 
         [InlineData(true)]
@@ -452,7 +458,50 @@ namespace Workstation.UaClient.UnitTests.Channels
             Opc.Ua.QualifiedName.Parse("4:Test"),
             new Opc.Ua.LocalizedText("foo", "fr-FR"),
             XmlElementParse(@"<Item AttributeA=""A"" AttributeB=""B"" />"),
-            new Opc.Ua.StatusCode(43)
+            new Opc.Ua.StatusCode(43),
+            new [] {true, false, true },
+            new sbyte[] { 1, 2, 3},
+            new short[] { 1, 2, 3},
+            new ushort[] { 1, 2, 3},
+            new int[] { 1, 2, 3},
+            new uint[] { 1, 2, 3},
+            new long[] { 1, 2, 3},
+            new ulong[] { 1, 2, 3},
+            new float[] { (float)1.3, (float)3.1, (float)4},
+            new double[] { 1.3, 3.1, 4.0},
+            new string[] { "a", "b", ""},
+            new DateTime[] { DateTime.UtcNow },
+            new Opc.Ua.Uuid[] { Opc.Ua.Uuid.Empty, new Opc.Ua.Uuid() },
+            new byte[][] { new byte[] { }, new byte[] { 1, 2, 3} },
+            new Opc.Ua.NodeId[] { new Opc.Ua.NodeId(5), new Opc.Ua.NodeId("b")},
+            new Opc.Ua.ExpandedNodeId[] { new Opc.Ua.ExpandedNodeId(4), new Opc.Ua.ExpandedNodeId("ee")},
+            new Opc.Ua.QualifiedName[] { Opc.Ua.QualifiedName.Parse("0:A"), Opc.Ua.QualifiedName.Parse("1:t") },
+            new Opc.Ua.LocalizedText[] {new Opc.Ua.LocalizedText("Yes", "en-US"), new Opc.Ua.LocalizedText("Ja", "de-DE")},
+            new [] { XmlElementParse(@"<Item AttributeA=""A"" AttributeB=""B"" />") },
+            new Opc.Ua.StatusCode[] {42, 43},
+            new Opc.Ua.Variant[] { new Opc.Ua.Variant(1)},
+            new [,] { { true, false }, { true, true}, { false, false} },
+            new byte[,] { { 1 }, { 2 }, { 3 } },
+            new sbyte[,] { { 1 }, { 2 }, { 3 } },
+            new short[,] { { 1, 2, 3 } },
+            new ushort[,] { { 1, 2 }, { 3, 9 } },
+            new int[,] { { 1, 2 }, { 3, 0 } },
+            new uint[,] { { 1, 2, 3 }, { 6, 0, 0 } },
+            new long[,] { { 1 } },
+            new ulong[,,] { { { 1, 2 }, { 3, 5 } }, { { 8, 2 }, { 3, 7 } }},
+            new float[,] { { (float)3.13456 } },
+            new double[,,,] { { {{ double.PositiveInfinity }, { double.NaN } }, { { double.NegativeInfinity }, { 3.1 } } } },
+            new byte[,][] { { new byte[] { 3, 4} }, { new byte[] { 5, 6, 7} } },
+            new string[,] { { "a", null},{ "b", "" } },
+            new DateTime[,] { { DateTime.MinValue } },
+            new Opc.Ua.Uuid[,] { { Opc.Ua.Uuid.Empty, new Opc.Ua.Uuid() } },
+            new Opc.Ua.NodeId[,] { { new Opc.Ua.NodeId(5) }, {new Opc.Ua.NodeId("b")} },
+            new Opc.Ua.ExpandedNodeId[,] { { new Opc.Ua.ExpandedNodeId(4) }, { new Opc.Ua.ExpandedNodeId("ee") } },
+            new Opc.Ua.QualifiedName[,,,,,,,] { { { { { { { { new Opc.Ua.QualifiedName("A") } } } } } } } },
+            new Opc.Ua.LocalizedText[,] { { new Opc.Ua.LocalizedText("Yes", "en-US"), new Opc.Ua.LocalizedText("Ja", "de-DE") }, { new Opc.Ua.LocalizedText("No", "en-US"), new Opc.Ua.LocalizedText("Nein", "de-DE") } },
+            new [,] { { XmlElementParse(@"<Item AttributeA=""A"" AttributeB=""B"" />") } },
+            new Opc.Ua.StatusCode[,,] { {{ 42, 43 }, { 100, 102 }, {100, 234 }, { 239, 199} } },
+            new Opc.Ua.Variant[,] { { new Opc.Ua.Variant(1), new Opc.Ua.Variant(2) }, { new Opc.Ua.Variant(3), new Opc.Ua.Variant(4)} },
         }
         .Select(x => new object[] { new Opc.Ua.Variant(x) });
 

--- a/UaClient.UnitTests/UnitTests/Channels/BinaryEncoderTests.Equivalency.cs
+++ b/UaClient.UnitTests/UnitTests/Channels/BinaryEncoderTests.Equivalency.cs
@@ -141,6 +141,16 @@ namespace Workstation.UaClient.UnitTests.Channels
                     .Should().Be(expectation.ServerPicoseconds);
             }
         }
+        
+        private class MatrixEquivalency : TypeMappingEquivalency<Opc.Ua.Matrix, Array>
+        {
+            protected override void Test(Opc.Ua.Matrix subject, Array expectation, string because, object[] becauseArgs)
+            {
+                var arr = subject.ToArray();
+                arr
+                    .Should().BeEquivalentTo(expectation);
+            }
+        }
 
         private class XmlEquivalency : TypeMappingEquivalency<XmlNode, XElement>
         {
@@ -182,6 +192,9 @@ namespace Workstation.UaClient.UnitTests.Channels
 
             // Xml
             AssertionOptions.AssertEquivalencyUsing(options => options.Using(new XmlEquivalency()));
+            
+            // Matrix/Multidim array
+            AssertionOptions.AssertEquivalencyUsing(options => options.Using(new MatrixEquivalency()));
         }
     }
 }


### PR DESCRIPTION
I finally got my hands on coverlet. This PR increase the overall code coverage of the unit tests from 34.2% to 37.2%. My medium-term plan is to reach 50%. After that it'll become more difficult. Once the low hanging fruits are picked, I'll open an issue to discuss how we can tackle the other half.

Btw: this time I found a bug in [FluentAssertions](https://github.com/fluentassertions/fluentassertions/issues/1167) :smile:.