### PR TITLE
Improve unit tests

### DIFF
--- a/UaClient.UnitTests/UnitTests/LocalizedTextTests.cs
+++ b/UaClient.UnitTests/UnitTests/LocalizedTextTests.cs
@@ -47,15 +47,42 @@ namespace Workstation.UaClient.UnitTests
         {
             if (shouldBeEqual)
             {
+                // Should().Be() is using Equal(object)
                 a
                     .Should().Be(b);
+                a
+                    .Should().NotBe(5);
+
+                // Test Equal(LocalizableText)
+                a.Equals(b)
+                    .Should().BeTrue();
+
+                // operator
+                (a == b)
+                    .Should().BeTrue();
+                (a != b)
+                    .Should().BeFalse();
+
                 a.GetHashCode()
                     .Should().Be(b.GetHashCode());
             }
             else
             {
-                a.Should()
-                    .NotBe(b);
+                // Should().Be() is using Equal(object)
+                a
+                    .Should().NotBe(b);
+                a
+                    .Should().NotBe(5);
+                
+                // Test Equal(LocalizableText)
+                a.Equals(b)
+                    .Should().BeFalse();
+
+                // operator
+                (a != b)
+                    .Should().BeTrue();
+                (a == b)
+                    .Should().BeFalse();
 
                 // This is technically not required but the current
                 // implementation fulfills this. If this should ever
@@ -64,6 +91,57 @@ namespace Workstation.UaClient.UnitTests
                 a.GetHashCode()
                     .Should().NotBe(b.GetHashCode());
             }
+        }
+
+        public static IEnumerable<object[]> EqualityNullData =>
+            LocalizedTexts.Select(id => new[] { id() });
+
+        [MemberData(nameof(EqualityNullData))]
+        [Theory]
+        public void EqualityNull(LocalizedText val)
+        {
+            (val == null)
+                .Should().BeFalse();
+            (val != null)
+                .Should().BeTrue();
+            (null == val)
+                .Should().BeFalse();
+            (null != val)
+                .Should().BeTrue();
+
+            // This is using Equals(object)
+            val.Should()
+                .NotBeNull();
+
+            val.Equals((LocalizedText)null)
+                .Should().BeFalse();
+        }
+
+        [InlineData("First text")]
+        [InlineData("Second text")]
+        [InlineData(null)]
+        [Theory]
+        public void ImplicitConversion(string val)
+        {
+            LocalizedText lt = val;
+
+            lt.Text
+                .Should().Be(val);
+            lt.Locale
+                .Should().Be("");
+
+            string txt2 = lt;
+
+            txt2
+                .Should().Be(val);
+        }
+
+        [Fact]
+        public void ImplicitConversionNull()
+        {
+            string txt = (LocalizedText)null;
+            txt
+                .Should().Be(null);
         }
     }
 }

--- a/UaClient.UnitTests/UnitTests/QualifiedNameTests.cs
+++ b/UaClient.UnitTests/UnitTests/QualifiedNameTests.cs
@@ -37,6 +37,7 @@ namespace Workstation.UaClient.UnitTests
 
         public static IEnumerable<Func<QualifiedName>> QualifiedNames { get; } = new Func<QualifiedName>[]
         {
+            () => new QualifiedName(null),
             () => new QualifiedName("A"),
             () => new QualifiedName("B"),
             () => new QualifiedName("A", 2),
@@ -65,9 +66,75 @@ namespace Workstation.UaClient.UnitTests
         public void Equality(QualifiedName a, QualifiedName b, bool shouldBeEqual)
         {
             if (shouldBeEqual)
-                a.Should().Be(b);
+            {
+                // Should().Be() is using Equal(object)
+                a
+                    .Should().Be(b);
+                a
+                    .Should().NotBe(5);
+
+                // Test Equal(QualifiedName)
+                a.Equals(b)
+                    .Should().BeTrue();
+
+                // operator
+                (a == b)
+                    .Should().BeTrue();
+                (a != b)
+                    .Should().BeFalse();
+
+                a.GetHashCode()
+                    .Should().Be(b.GetHashCode());
+            }
             else
-                a.Should().NotBe(b);
+            {
+                // Should().Be() is using Equal(object)
+                a
+                    .Should().NotBe(b);
+                a
+                    .Should().NotBe(5);
+                
+                // Test Equal(QualifiedName)
+                a.Equals(b)
+                    .Should().BeFalse();
+
+                // operator
+                (a != b)
+                    .Should().BeTrue();
+                (a == b)
+                    .Should().BeFalse();
+
+                // This is technically not required but the current
+                // implementation fulfills this. If this should ever
+                // fail it could be bad luck or the the implementation
+                // is really broken.
+                a.GetHashCode()
+                    .Should().NotBe(b.GetHashCode());
+            }
+        }
+        
+        public static IEnumerable<object[]> EqualityNullData =>
+            QualifiedNames.Select(id => new[] { id() });
+
+        [MemberData(nameof(EqualityNullData))]
+        [Theory]
+        public void EqualityNull(QualifiedName val)
+        {
+            (val == null)
+                .Should().BeFalse();
+            (val != null)
+                .Should().BeTrue();
+            (null == val)
+                .Should().BeFalse();
+            (null != val)
+                .Should().BeTrue();
+
+            // This is using Equals(object)
+            val.Should()
+                .NotBeNull();
+
+            val.Equals((QualifiedName)null)
+                .Should().BeFalse();
         }
 
         [InlineData("0:ABC", 0, "ABC")]

--- a/UaClient.UnitTests/Workstation.UaClient.UnitTests.csproj
+++ b/UaClient.UnitTests/Workstation.UaClient.UnitTests.csproj
@@ -22,6 +22,10 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="coverlet.collector" Version="1.1.0">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
     <PackageReference Include="FluentAssertions" Version="5.9.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="3.0.0" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="3.0.0" />

--- a/UaClient.UnitTests/coverlet.runsettings
+++ b/UaClient.UnitTests/coverlet.runsettings
@@ -1,0 +1,16 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<RunSettings>
+  <DataCollectionRunSettings>
+    <DataCollectors>
+      <DataCollector friendlyName="XPlat code coverage">
+        <Configuration>
+          <Format>json,cobertura</Format>
+          <ExcludeByAttribute>ObsoleteAttribute,GeneratedCodeAttribute,CompilerGeneratedAttribute</ExcludeByAttribute>
+          <ExcludeByFile>**\*.generated.cs</ExcludeByFile> <!-- Absolute or relative file paths -->
+          <SingleHit>false</SingleHit>
+          <UseSourceLink>true</UseSourceLink>
+        </Configuration>
+      </DataCollector>
+    </DataCollectors>
+  </DataCollectionRunSettings>
+</RunSettings>

--- a/UaClient/ServiceModel/Ua/NodeId.cs
+++ b/UaClient/ServiceModel/Ua/NodeId.cs
@@ -237,7 +237,18 @@ namespace Workstation.ServiceModel.Ua
         public override int GetHashCode()
         {
             int result = this.NamespaceIndex.GetHashCode();
-            result = (397 * result) ^ this.Identifier.GetHashCode();
+
+            if (this.IdType == IdType.Opaque)
+            {
+                foreach (var b in (byte[])this.Identifier)
+                {
+                    result = (397 * result) ^ b.GetHashCode();
+                }
+            }
+            else
+            {
+                result = (397 * result) ^ this.Identifier.GetHashCode();
+            }
             return result;
         }
 


### PR DESCRIPTION
This PR increase the code and branch coverage to nearly 100% for `LocalizedText` (100%), `QualifiedName` (100%) and `NodeId` (98.5%/97.1%). One test is failing. The reason is that the `GetHashCode` method of the node ID

https://github.com/convertersystems/opc-ua-client/blob/a3b0a496233115ccd837bd1602fab17f8af657a8/UaClient/ServiceModel/Ua/NodeId.cs#L237-L242

The the hash code of the identifier is linked on the reference and not the value in the case of a byte array, so two sequential equal arrays have different hash codes.