### PR TITLE
Add some minor unit tests

### DIFF
--- a/UaClient.UnitTests/UnitTests/DataTypeIdAttributeTests.cs
+++ b/UaClient.UnitTests/UnitTests/DataTypeIdAttributeTests.cs
@@ -1,0 +1,24 @@
+﻿using FluentAssertions;
+using System;
+using System.Collections.Generic;
+using System.Text;
+using Workstation.ServiceModel.Ua;
+using Xunit;
+
+namespace Workstation.UaClient.UnitTests
+{
+    public class DataTypeIdAttributeTests
+    {
+        public static IEnumerable<object[]> CreateData => ExpandedNodeIdTests.ParseData;
+
+        [MemberData(nameof(CreateData))]
+        [Theory]
+        public void Create(string s, ExpandedNodeId id)
+        {
+            var att = new DataTypeIdAttribute(s);
+
+            att.NodeId
+                .Should().Be(id);
+        }
+    }
+}

--- a/UaClient.UnitTests/UnitTests/IssuedIdentityTests.cs
+++ b/UaClient.UnitTests/UnitTests/IssuedIdentityTests.cs
@@ -1,0 +1,24 @@
+﻿using FluentAssertions;
+using System;
+using System.Collections.Generic;
+using System.Text;
+using Workstation.ServiceModel.Ua;
+using Xunit;
+
+namespace Workstation.UaClient.UnitTests
+{
+    public class IssuedIdentityTests
+    {
+        [InlineData(null)]
+        [InlineData(new byte[] { })]
+        [InlineData(new byte[] { 0x45, 0xff})]
+        [Theory]
+        public void Create(byte[] tokenData)
+        {
+            var id = new IssuedIdentity(tokenData);
+
+            id.TokenData
+                .Should().BeSameAs(tokenData);
+        }
+    }
+}

--- a/UaClient.UnitTests/UnitTests/MonitoredItemAttributeTests.cs
+++ b/UaClient.UnitTests/UnitTests/MonitoredItemAttributeTests.cs
@@ -1,0 +1,37 @@
+﻿using FluentAssertions;
+using System;
+using System.Collections.Generic;
+using System.Text;
+using Workstation.ServiceModel.Ua;
+using Xunit;
+
+namespace Workstation.UaClient.UnitTests
+{
+    public class MonitoredItemAttributeTests
+    {
+        [Fact]
+        public void Create()
+        {
+            var att = new MonitoredItemAttribute("s=Hello");
+
+            att.AttributeId
+                .Should().Be(AttributeIds.Value);
+            att.DataChangeTrigger
+                .Should().Be(DataChangeTrigger.StatusValue);
+            att.DeadbandType
+                .Should().Be(DeadbandType.None);
+            att.DeadbandValue
+                .Should().Be(0.0);
+            att.DiscardOldest
+                .Should().BeTrue();
+            att.IndexRange
+                .Should().BeNull();
+            att.NodeId
+                .Should().Be("s=Hello");
+            att.QueueSize
+                .Should().Be(0);
+            att.SamplingInterval
+                .Should().Be(-1);
+        }
+    }
+}

--- a/UaClient.UnitTests/UnitTests/UaApplicationOptionsTests.cs
+++ b/UaClient.UnitTests/UnitTests/UaApplicationOptionsTests.cs
@@ -12,14 +12,10 @@ namespace Workstation.UaClient.UnitTests
         [Fact]
         public void UaTcpTransportChannelOptionsDefaults()
         {
-            var lowestBufferSize = 1024u;
+            var lowestBufferSize = 8192u;
 
             var options = new UaTcpTransportChannelOptions();
 
-            options.LocalMaxChunkCount
-                .Should().BeGreaterOrEqualTo(lowestBufferSize);
-            options.LocalMaxMessageSize
-                .Should().BeGreaterOrEqualTo(lowestBufferSize);
             options.LocalReceiveBufferSize
                 .Should().BeGreaterOrEqualTo(lowestBufferSize);
             options.LocalSendBufferSize

--- a/UaClient.UnitTests/UnitTests/UaApplicationOptionsTests.cs
+++ b/UaClient.UnitTests/UnitTests/UaApplicationOptionsTests.cs
@@ -1,0 +1,54 @@
+﻿using FluentAssertions;
+using System;
+using System.Collections.Generic;
+using System.Text;
+using Workstation.ServiceModel.Ua;
+using Xunit;
+
+namespace Workstation.UaClient.UnitTests
+{
+    public class UaApplicationOptionsTests
+    {
+        [Fact]
+        public void UaTcpTransportChannelOptionsDefaults()
+        {
+            var lowestBufferSize = 1024u;
+
+            var options = new UaTcpTransportChannelOptions();
+
+            options.LocalMaxChunkCount
+                .Should().BeGreaterOrEqualTo(lowestBufferSize);
+            options.LocalMaxMessageSize
+                .Should().BeGreaterOrEqualTo(lowestBufferSize);
+            options.LocalReceiveBufferSize
+                .Should().BeGreaterOrEqualTo(lowestBufferSize);
+            options.LocalSendBufferSize
+                .Should().BeGreaterOrEqualTo(lowestBufferSize);
+        }
+
+        [Fact]
+        public void UaTcpSecureChannelOptionsDefaults()
+        {
+            var shortestTimespan = TimeSpan.FromMilliseconds(100);
+
+            var options = new UaTcpSecureChannelOptions();
+
+            TimeSpan.FromMilliseconds(options.TimeoutHint)
+                .Should().BeGreaterOrEqualTo(shortestTimespan);
+
+            options.DiagnosticsHint
+                .Should().Be(0);
+        }
+
+        [Fact]
+        public void UaTcpSessionChannelOptionsDefaults()
+        {
+            var shortestTimespan = TimeSpan.FromMilliseconds(100);
+
+            var options = new UaTcpSessionChannelOptions();
+
+            TimeSpan.FromMilliseconds(options.SessionTimeout)
+                .Should().BeGreaterOrEqualTo(shortestTimespan);
+        }
+    }
+}

--- a/UaClient.UnitTests/UnitTests/UserNameIdentityTests.cs
+++ b/UaClient.UnitTests/UnitTests/UserNameIdentityTests.cs
@@ -1,0 +1,27 @@
+﻿using FluentAssertions;
+using System;
+using System.Collections.Generic;
+using System.Text;
+using Workstation.ServiceModel.Ua;
+using Xunit;
+
+namespace Workstation.UaClient.UnitTests
+{
+    public class UserNameIdentityTests
+    {
+        [InlineData("", "")]
+        [InlineData("UserName", "Password")]
+        [InlineData(null, "Password")]
+        [InlineData("UserName", null)]
+        [Theory]
+        public void Create(string userName, string password)
+        {
+            var user = new UserNameIdentity(userName, password);
+
+            user.UserName
+                .Should().Be(userName);
+            user.Password
+                .Should().Be(password);
+        }
+    }
+}

--- a/UaClient.UnitTests/UnitTests/X509IdentityTests.cs
+++ b/UaClient.UnitTests/UnitTests/X509IdentityTests.cs
@@ -1,0 +1,27 @@
+﻿using FluentAssertions;
+using Org.BouncyCastle.Asn1.X509;
+using Org.BouncyCastle.Crypto.Parameters;
+using Org.BouncyCastle.Math;
+using Org.BouncyCastle.X509;
+using System;
+using System.Collections.Generic;
+using System.Text;
+using Workstation.ServiceModel.Ua;
+using Xunit;
+
+namespace Workstation.UaClient.UnitTests
+{
+    public class X509IdentityTests
+    {
+        [Fact]
+        public void CreateNull()
+        {
+            var id = new X509Identity(null, null);
+
+            id.Certificate
+                .Should().BeNull();
+            id.PrivateKey
+                .Should().BeNull();
+        }
+    }
+}

--- a/UaClient.UnitTests/UnitTests/XmlEncodingIdAttributeTests.cs
+++ b/UaClient.UnitTests/UnitTests/XmlEncodingIdAttributeTests.cs
@@ -1,0 +1,24 @@
+﻿using FluentAssertions;
+using System;
+using System.Collections.Generic;
+using System.Text;
+using Workstation.ServiceModel.Ua;
+using Xunit;
+
+namespace Workstation.UaClient.UnitTests
+{
+    public class XmlEncodingIdAttributeTests
+    {
+        public static IEnumerable<object[]> CreateData => ExpandedNodeIdTests.ParseData;
+
+        [MemberData(nameof(CreateData))]
+        [Theory]
+        public void Create(string s, ExpandedNodeId id)
+        {
+            var att = new XmlEncodingIdAttribute(s);
+
+            att.NodeId
+                .Should().Be(id);
+        }
+    }
+}


### PR DESCRIPTION
This is mainly to increase the covered file count. For the UaTcpChannelOptions default, I only test for a lower bound. Testing the actual value would be also possible, but I thought that this is to strict.