### PR TITLE
Add collection unittests

### DIFF
--- a/UaClient.UnitTests/UnitTests/ErrorsContainerTests.cs
+++ b/UaClient.UnitTests/UnitTests/ErrorsContainerTests.cs
@@ -1,0 +1,212 @@
+﻿using FluentAssertions;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using Workstation.Collections;
+using Xunit;
+
+namespace Workstation.UaClient.UnitTests
+{
+    public class ErrorsContainerTests
+    {
+        private const string TestProperty1 = "Property1";
+        private const string TestProperty2 = "Property2";
+
+        public static IEnumerable<object[]> TestProperties { get; } = new[]
+        {
+            null,
+            "",
+            "TestProperty"
+        }
+        .Select(v => new object[] { v });
+
+        [MemberData(nameof(TestProperties))]
+        [Theory]
+        public void Create(string property)
+        {
+            var container = new ErrorsContainer<int>(s => { });
+
+            container.HasErrors
+                .Should().BeFalse();
+
+            container.GetErrors(property)
+                .Should().BeEmpty();
+        }
+
+        [Fact]
+        public void CreateNull()
+        {
+            Action<string> action = null;
+
+            action.Invoking(a => new ErrorsContainer<int>(a))
+                .Should().Throw<ArgumentNullException>();
+        }
+
+        [MemberData(nameof(TestProperties))]
+        [Theory]
+        public void InsertSingle(string property)
+        {
+            var called = 0;
+            var container = new ErrorsContainer<int>(_ => called++);
+
+            called
+                .Should().Be(0);
+
+            container.SetErrors(property, new[] { 1 });
+
+            called
+                .Should().Be(1);
+
+            container.HasErrors
+                .Should().BeTrue();
+
+            container.GetErrors(property)
+                .Should().ContainSingle()
+                .Which
+                .Should().Be(1);
+            
+            called
+                .Should().Be(1);
+        }
+
+        [MemberData(nameof(TestProperties))]
+        [Theory]
+        public void InsertEmpty(string property)
+        {
+            var called = 0;
+            var container = new ErrorsContainer<int>(_ => called++);
+
+            container.SetErrors(property, Enumerable.Empty<int>());
+
+            container.HasErrors
+                .Should().BeFalse();
+
+            container.GetErrors(property)
+                .Should().BeEmpty();
+            
+            called
+                .Should().Be(0);
+        }
+
+        [MemberData(nameof(TestProperties))]
+        [Theory]
+        public void InsertNull(string property)
+        {
+            var called = 0;
+            var container = new ErrorsContainer<int>(_ => called++);
+
+            container.SetErrors(property, null);
+
+            container.HasErrors
+                .Should().BeFalse();
+
+            container.GetErrors(property)
+                .Should().BeEmpty();
+
+            called
+                .Should().Be(0);
+        }
+
+        [MemberData(nameof(TestProperties))]
+        [Theory]
+        public void InsertSingleAndRemove(string property)
+        {
+            var called = 0;
+            var container = new ErrorsContainer<int>(_ => called++);
+
+            container.SetErrors(property, new[] { 1 });
+            container.SetErrors(property, null);
+
+            called
+                .Should().Be(2);
+
+            container.HasErrors
+                .Should().BeFalse();
+
+            container.GetErrors(property)
+                .Should().BeEmpty();
+        }
+
+        [MemberData(nameof(TestProperties))]
+        [Theory]
+        public void InsertSingleAndClear(string property)
+        {
+            var called = 0;
+            var container = new ErrorsContainer<int>(_ => called++);
+
+            container.SetErrors(property, new[] { 1 });
+            container.ClearErrors(property);
+
+            called
+                .Should().Be(2);
+
+            container.HasErrors
+                .Should().BeFalse();
+
+            container.GetErrors(property)
+                .Should().BeEmpty();
+        }
+
+        [MemberData(nameof(TestProperties))]
+        [Theory]
+        public void InsertMany(string property)
+        {
+            var called = 0;
+            var container = new ErrorsContainer<int>(_ => called++);
+
+            container.SetErrors(property, new[] { 1 });
+            container.SetErrors(property, new[] { 2, 3, 6 });
+
+            called
+                .Should().Be(2);
+
+            container.HasErrors
+                .Should().BeTrue();
+
+            container.GetErrors(property)
+                .Should().BeEquivalentTo(new[] { 2, 3, 6 });
+        }
+        
+        [MemberData(nameof(TestProperties))]
+        [Theory]
+        public void InsertSame(string property)
+        {
+            var called = 0;
+            var container = new ErrorsContainer<int>(_ => called++);
+
+            container.SetErrors(property, new[] { 1, 2, 4 });
+            container.SetErrors(property, new[] { 1, 2, 4 });
+
+            called
+                .Should().Be(2);
+
+            container.HasErrors
+                .Should().BeTrue();
+
+            container.GetErrors(property)
+                .Should().BeEquivalentTo(new[] { 1, 2, 4 });
+        }
+
+        [Fact]
+        public void InsertForTwoProperties()
+        {
+            var called = 0;
+            var container = new ErrorsContainer<int>(_ => called++);
+
+            container.SetErrors(TestProperty1, new[] { 1, 2, 4 });
+            container.SetErrors(TestProperty2, new[] { 5, 6 });
+
+            called
+                .Should().Be(2);
+
+            container.HasErrors
+                .Should().BeTrue();
+
+            container.GetErrors(TestProperty1)
+                .Should().BeEquivalentTo(new[] { 1, 2, 4 });
+            container.GetErrors(TestProperty2)
+                .Should().BeEquivalentTo(new[] { 5, 6 });
+        }
+    }
+}

--- a/UaClient.UnitTests/UnitTests/ObservableQueueTests.cs
+++ b/UaClient.UnitTests/UnitTests/ObservableQueueTests.cs
@@ -1,0 +1,232 @@
+﻿using FluentAssertions;
+using System;
+using System.Collections.Generic;
+using System.Collections.Specialized;
+using System.Linq;
+using System.Text;
+using Workstation.Collections;
+using Xunit;
+
+namespace Workstation.UaClient.UnitTests
+{
+    public class ObservableQueueTests
+    {
+        [Fact]
+        public void ObservePropertyChanged()
+        {
+            var queue = new ObservableQueue<int>();
+            
+            var props = new List<string>();
+            var itemQuery = props.Where(p => p == "Item[]");
+            var countQuery = props.Where(p => p == "Count");
+
+            queue.PropertyChanged += (o, e) => props.Add(e.PropertyName);
+
+            queue.Enqueue(1);
+            itemQuery
+                .Should().HaveCount(1);
+            countQuery
+                .Should().HaveCount(1);
+
+            queue.Enqueue(2);
+            itemQuery
+                .Should().HaveCount(2);
+            countQuery
+                .Should().HaveCount(2);
+
+            queue.Enqueue(3);
+            itemQuery
+                .Should().HaveCount(3);
+            countQuery
+                .Should().HaveCount(3);
+
+            queue.Dequeue();
+            itemQuery
+                .Should().HaveCount(4);
+            countQuery
+                .Should().HaveCount(4);
+
+            queue.Clear();
+            itemQuery
+                .Should().HaveCount(5);
+            countQuery
+                .Should().HaveCount(5);
+        }
+        
+        [Fact]
+        public void ObservePropertyChangedEmptyClear()
+        {
+            var queue = new ObservableQueue<int>();
+            int count = 0;
+
+            queue.PropertyChanged += (o, e) => count++;
+
+            queue.Clear();
+
+            count
+                .Should().Be(0);
+        }
+
+        [Fact]
+        public void ObserveCollectionChanged()
+        {
+            var queue = new ObservableQueue<string>();
+            var args = new List<NotifyCollectionChangedEventArgs>();
+
+            queue.CollectionChanged += (o, e) => args.Add(e);
+
+            queue.Enqueue("A");
+            args
+                .Should().ContainSingle()
+                .Which
+                .Should().BeEquivalentTo(
+                    new NotifyCollectionChangedEventArgs(NotifyCollectionChangedAction.Add, "A", 0)
+                );
+
+            args.Clear();
+            queue.Enqueue("B");
+            args
+                .Should().ContainSingle()
+                .Which
+                .Should().BeEquivalentTo(
+                    new NotifyCollectionChangedEventArgs(NotifyCollectionChangedAction.Add, "B", 1)
+                );
+
+            args.Clear();
+            queue.Enqueue("C");
+            args
+                .Should().ContainSingle()
+                .Which
+                .Should().BeEquivalentTo(
+                    new NotifyCollectionChangedEventArgs(NotifyCollectionChangedAction.Add, "C", 2)
+                );
+
+            args.Clear();
+            queue.Dequeue();
+            args
+                .Should().ContainSingle()
+                .Which
+                .Should().BeEquivalentTo(
+                    new NotifyCollectionChangedEventArgs(NotifyCollectionChangedAction.Remove, "A", 0)
+                );
+
+            args.Clear();
+            queue.Clear();
+            args
+                .Should().ContainSingle()
+                .Which
+                .Should().BeEquivalentTo(
+                    new NotifyCollectionChangedEventArgs(NotifyCollectionChangedAction.Reset)
+                );
+        }
+        
+        [Fact]
+        public void ObserveCollectionChangedEmptyClear()
+        {
+            var queue = new ObservableQueue<int>();
+            int count = 0;
+
+            queue.CollectionChanged += (o, e) => count++;
+
+            queue.Clear();
+
+            count
+                .Should().Be(0);
+        }
+        
+        [Fact]
+        public void ObservePropertyChangedFixedSize()
+        {
+            var queue = new ObservableQueue<int>(2, isFixedSize: true);
+            
+            var props = new List<string>();
+            var itemQuery = props.Where(p => p == "Item[]");
+            var countQuery = props.Where(p => p == "Count");
+
+            queue.PropertyChanged += (o, e) => props.Add(e.PropertyName);
+
+            queue.Enqueue(1);
+            itemQuery
+                .Should().HaveCount(1);
+            countQuery
+                .Should().HaveCount(1);
+
+            queue.Enqueue(2);
+            itemQuery
+                .Should().HaveCount(2);
+            countQuery
+                .Should().HaveCount(2);
+
+            queue.Enqueue(3);
+            itemQuery
+                .Should().HaveCount(4);
+            countQuery
+                .Should().HaveCount(4);
+
+            queue.Dequeue();
+            itemQuery
+                .Should().HaveCount(5);
+            countQuery
+                .Should().HaveCount(5);
+
+            queue.Clear();
+            itemQuery
+                .Should().HaveCount(6);
+            countQuery
+                .Should().HaveCount(6);
+        }
+        
+        [Fact]
+        public void ObserveCollectionChangedFixedSize()
+        {
+            var queue = new ObservableQueue<string>(2, isFixedSize: true);
+            var args = new List<NotifyCollectionChangedEventArgs>();
+
+            queue.CollectionChanged += (o, e) => args.Add(e);
+
+            queue.Enqueue("A");
+            args
+                .Should().ContainSingle()
+                .Which
+                .Should().BeEquivalentTo(
+                    new NotifyCollectionChangedEventArgs(NotifyCollectionChangedAction.Add, "A", 0)
+                );
+
+            args.Clear();
+            queue.Enqueue("B");
+            args
+                .Should().ContainSingle()
+                .Which
+                .Should().BeEquivalentTo(
+                    new NotifyCollectionChangedEventArgs(NotifyCollectionChangedAction.Add, "B", 1)
+                 );
+
+            args.Clear();
+            queue.Enqueue("C");
+            args
+                .Should().BeEquivalentTo(new[]
+                {
+                    new NotifyCollectionChangedEventArgs(NotifyCollectionChangedAction.Remove, "A", 0),
+                    new NotifyCollectionChangedEventArgs(NotifyCollectionChangedAction.Add, "C", 1)
+                });
+
+            args.Clear();
+            queue.Dequeue();
+            args
+                .Should().ContainSingle()
+                .Which
+                .Should().BeEquivalentTo(
+                    new NotifyCollectionChangedEventArgs(NotifyCollectionChangedAction.Remove, "B", 0)
+                );
+
+            args.Clear();
+            queue.Clear();
+            args
+                .Should().ContainSingle()
+                .Which
+                .Should().BeEquivalentTo(
+                    new NotifyCollectionChangedEventArgs(NotifyCollectionChangedAction.Reset)
+                );
+        }
+    }
+}

--- a/UaClient/Collections/ObservableQueue.cs
+++ b/UaClient/Collections/ObservableQueue.cs
@@ -50,6 +50,11 @@ namespace Workstation.Collections
         /// </summary>
         public new void Clear()
         {
+            if (this.Count == 0)
+            {
+                return;
+            }
+
             base.Clear();
             this.OnPropertyChanged("Count");
             this.OnPropertyChanged("Item[]");


### PR DESCRIPTION
Some more tests. With that PR (and the other open PR) we are now on a code coverage ratio of 49.5 %. I changed the behavior of the `ObservableQueue.Clear` method, because I think it should not emit change events if nothing has changed.