### PR TITLE
Nullable reference types

### DIFF
--- a/.github/workflows/unittests.yml
+++ b/.github/workflows/unittests.yml
@@ -9,10 +9,16 @@ jobs:
     
     steps:
     - uses: actions/checkout@v1
-    - name: Setup .NET Core
+    - name: Setup .NET Core 2.2
       uses: actions/setup-dotnet@v1
       with:
-        dotnet-version: 2.2.108
+        dotnet-version: '2.2.108'
+    - name: Setup .NET Core 3.0
+      uses: actions/setup-dotnet@v1
+      with:
+        dotnet-version: '3.0.100'
+    - name: Workaround see https://github.com/actions/setup-dotnet/issues/25#issuecomment-557570168
+      run: rsync -a ${DOTNET_ROOT/3.0.100/2.2.108}/* $DOTNET_ROOT/
     - name: Build with dotnet
       run: dotnet build --configuration Release
     - name: Run unit tests

--- a/UaClient/Internal/System.Diagnostics.CodeAnalysis.cs
+++ b/UaClient/Internal/System.Diagnostics.CodeAnalysis.cs
@@ -1,0 +1,61 @@
+﻿// taken from https://github.com/dotnet/standard/blob/master/src/netstandard/ref/System.Diagnostics.CodeAnalysis.cs
+
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+#if NETSTANDARD2_0
+namespace System.Diagnostics.CodeAnalysis
+{
+    [System.AttributeUsageAttribute(System.AttributeTargets.Field | System.AttributeTargets.Parameter | System.AttributeTargets.Property, Inherited = false)]
+    internal sealed partial class AllowNullAttribute : System.Attribute
+    {
+        public AllowNullAttribute() { }
+    }
+    [System.AttributeUsageAttribute(System.AttributeTargets.Field | System.AttributeTargets.Parameter | System.AttributeTargets.Property, Inherited = false)]
+    internal sealed partial class DisallowNullAttribute : System.Attribute
+    {
+        public DisallowNullAttribute() { }
+    }
+    [System.AttributeUsageAttribute(System.AttributeTargets.Method, Inherited = false)]
+    internal sealed partial class DoesNotReturnAttribute : System.Attribute
+    {
+        public DoesNotReturnAttribute() { }
+    }
+    [System.AttributeUsageAttribute(System.AttributeTargets.Parameter, Inherited = false)]
+    internal sealed partial class DoesNotReturnIfAttribute : System.Attribute
+    {
+        public DoesNotReturnIfAttribute(bool parameterValue) { }
+        public bool ParameterValue { get { throw null; } }
+    }
+    [System.AttributeUsageAttribute(System.AttributeTargets.Field | System.AttributeTargets.Parameter | System.AttributeTargets.Property | System.AttributeTargets.ReturnValue, Inherited = false)]
+    internal sealed partial class MaybeNullAttribute : System.Attribute
+    {
+        public MaybeNullAttribute() { }
+    }
+    [System.AttributeUsageAttribute(System.AttributeTargets.Parameter, Inherited = false)]
+    internal sealed partial class MaybeNullWhenAttribute : System.Attribute
+    {
+        public MaybeNullWhenAttribute(bool returnValue) { }
+        public bool ReturnValue { get { throw null; } }
+    }
+    [System.AttributeUsageAttribute(System.AttributeTargets.Field | System.AttributeTargets.Parameter | System.AttributeTargets.Property | System.AttributeTargets.ReturnValue, Inherited = false)]
+    internal sealed partial class NotNullAttribute : System.Attribute
+    {
+        public NotNullAttribute() { }
+    }
+    [System.AttributeUsageAttribute(System.AttributeTargets.Parameter | System.AttributeTargets.Property | System.AttributeTargets.ReturnValue, AllowMultiple = true, Inherited = false)]
+    internal sealed partial class NotNullIfNotNullAttribute : System.Attribute
+    {
+        public NotNullIfNotNullAttribute(string parameterName) { }
+        public string ParameterName { get { throw null; } }
+    }
+    [System.AttributeUsageAttribute(System.AttributeTargets.Parameter, Inherited = false)]
+    internal sealed partial class NotNullWhenAttribute : System.Attribute
+    {
+        public NotNullWhenAttribute(bool returnValue) { }
+        public bool ReturnValue { get { throw null; } }
+    }
+}
+
+#endif

--- a/UaClient/ServiceModel/Ua/ExpandedNodeId.cs
+++ b/UaClient/ServiceModel/Ua/ExpandedNodeId.cs
@@ -3,8 +3,11 @@
 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
 using System.Text;
+
+#nullable enable
 
 namespace Workstation.ServiceModel.Ua
 {
@@ -12,35 +15,35 @@ namespace Workstation.ServiceModel.Ua
     {
         public static readonly ExpandedNodeId Null = new ExpandedNodeId(0);
 
-        public ExpandedNodeId(uint identifier, string namespaceUri = null, uint serverIndex = 0)
+        public ExpandedNodeId(uint identifier, string? namespaceUri = null, uint serverIndex = 0)
         {
             this.NodeId = new NodeId(identifier);
             this.NamespaceUri = namespaceUri;
             this.ServerIndex = serverIndex;
         }
 
-        public ExpandedNodeId(string identifier, string namespaceUri = null, uint serverIndex = 0)
+        public ExpandedNodeId(string identifier, string? namespaceUri = null, uint serverIndex = 0)
         {
             this.NodeId = new NodeId(identifier);
             this.NamespaceUri = namespaceUri;
             this.ServerIndex = serverIndex;
         }
 
-        public ExpandedNodeId(Guid identifier, string namespaceUri = null, uint serverIndex = 0)
+        public ExpandedNodeId(Guid identifier, string? namespaceUri = null, uint serverIndex = 0)
         {
             this.NodeId = new NodeId(identifier);
             this.NamespaceUri = namespaceUri;
             this.ServerIndex = serverIndex;
         }
 
-        public ExpandedNodeId(byte[] identifier, string namespaceUri = null, uint serverIndex = 0)
+        public ExpandedNodeId(byte[] identifier, string? namespaceUri = null, uint serverIndex = 0)
         {
             this.NodeId = new NodeId(identifier);
             this.NamespaceUri = namespaceUri;
             this.ServerIndex = serverIndex;
         }
 
-        public ExpandedNodeId(NodeId identifier, string namespaceUri = null, uint serverIndex = 0)
+        public ExpandedNodeId(NodeId identifier, string? namespaceUri = null, uint serverIndex = 0)
         {
             this.NodeId = identifier;
             this.NamespaceUri = namespaceUri;
@@ -49,11 +52,11 @@ namespace Workstation.ServiceModel.Ua
 
         public NodeId NodeId { get; }
 
-        public string NamespaceUri { get; }
+        public string? NamespaceUri { get; }
 
         public uint ServerIndex { get; }
 
-        public static bool operator ==(ExpandedNodeId a, ExpandedNodeId b)
+        public static bool operator ==(ExpandedNodeId? a, ExpandedNodeId? b)
         {
             if (ReferenceEquals(a, b))
             {
@@ -68,17 +71,17 @@ namespace Workstation.ServiceModel.Ua
             return (a.NodeId == b.NodeId) && (a.NamespaceUri == b.NamespaceUri) && (a.ServerIndex == b.ServerIndex);
         }
 
-        public static bool operator !=(ExpandedNodeId a, ExpandedNodeId b)
+        public static bool operator !=(ExpandedNodeId? a, ExpandedNodeId? b)
         {
             return !(a == b);
         }
 
-        public static bool IsNull(ExpandedNodeId nodeId)
+        public static bool IsNull(ExpandedNodeId? nodeId)
         {
             return (nodeId == null) || NodeId.IsNull(nodeId.NodeId);
         }
 
-        public static NodeId ToNodeId(ExpandedNodeId value, IList<string> namespaceUris)
+        public static NodeId ToNodeId(ExpandedNodeId value, IList<string?>? namespaceUris)
         {
             if (ReferenceEquals(value, null))
             {
@@ -86,7 +89,7 @@ namespace Workstation.ServiceModel.Ua
             }
 
             ushort ns = value.NodeId.NamespaceIndex;
-            string nsu = value.NamespaceUri;
+            var nsu = value.NamespaceUri;
             if (namespaceUris != null && !string.IsNullOrEmpty(nsu))
             {
                 int i = namespaceUris.IndexOf(nsu);
@@ -112,7 +115,7 @@ namespace Workstation.ServiceModel.Ua
             }
         }
 
-        public static bool TryParse(string s, out ExpandedNodeId value)
+        public static bool TryParse(string s, [NotNullWhen(returnValue: true)] out ExpandedNodeId? value)
         {
             try
             {
@@ -129,7 +132,7 @@ namespace Workstation.ServiceModel.Ua
                     s = s.Substring(pos + 1);
                 }
 
-                string nsu = null;
+                string? nsu = null;
                 if (s.StartsWith("nsu=", StringComparison.Ordinal))
                 {
                     int pos = s.IndexOf(';');
@@ -142,8 +145,7 @@ namespace Workstation.ServiceModel.Ua
                     s = s.Substring(pos + 1);
                 }
 
-                NodeId nodeId = null;
-                if (NodeId.TryParse(s, out nodeId))
+                if (NodeId.TryParse(s, out var nodeId))
                 {
                     value = new ExpandedNodeId(nodeId, nsu, svr);
                     return true;
@@ -161,8 +163,7 @@ namespace Workstation.ServiceModel.Ua
 
         public static ExpandedNodeId Parse(string s)
         {
-            ExpandedNodeId value;
-            if (!ExpandedNodeId.TryParse(s, out value))
+            if (!ExpandedNodeId.TryParse(s, out var value))
             {
                 throw new ServiceResultException(StatusCodes.BadNodeIdInvalid);
             }
@@ -170,7 +171,7 @@ namespace Workstation.ServiceModel.Ua
             return value;
         }
 
-        public override bool Equals(object o)
+        public override bool Equals(object? o)
         {
             if (o is ExpandedNodeId)
             {

--- a/UaClient/ServiceModel/Ua/ExtensionObject.cs
+++ b/UaClient/ServiceModel/Ua/ExtensionObject.cs
@@ -5,6 +5,8 @@ using System.Linq;
 using System.Reflection;
 using System.Xml.Linq;
 
+#nullable enable
+
 namespace Workstation.ServiceModel.Ua
 {
     public enum BodyType
@@ -17,7 +19,7 @@ namespace Workstation.ServiceModel.Ua
 
     public sealed class ExtensionObject
     {
-        public ExtensionObject(byte[] body, ExpandedNodeId typeId)
+        public ExtensionObject(byte[]? body, ExpandedNodeId? typeId)
         {
             if (body == null)
             {
@@ -30,7 +32,7 @@ namespace Workstation.ServiceModel.Ua
             this.TypeId = typeId;
         }
 
-        public ExtensionObject(XElement body, ExpandedNodeId typeId)
+        public ExtensionObject(XElement? body, ExpandedNodeId? typeId)
         {
             if (body == null)
             {
@@ -43,7 +45,7 @@ namespace Workstation.ServiceModel.Ua
             this.TypeId = typeId;
         }
 
-        public ExtensionObject(IEncodable body, ExpandedNodeId typeId)
+        public ExtensionObject(IEncodable? body, ExpandedNodeId? typeId)
         {
             if (body == null)
             {
@@ -56,7 +58,7 @@ namespace Workstation.ServiceModel.Ua
             this.TypeId = typeId;
         }
 
-        public ExtensionObject(IEncodable body)
+        public ExtensionObject(IEncodable? body)
         {
             if (body == null)
             {
@@ -69,9 +71,9 @@ namespace Workstation.ServiceModel.Ua
             this.TypeId = body.GetType().GetTypeInfo().GetCustomAttribute<BinaryEncodingIdAttribute>(false)?.NodeId ?? throw new ServiceResultException(StatusCodes.BadDataEncodingUnsupported);
         }
 
-        public object Body { get; }
+        public object? Body { get; }
 
-        public ExpandedNodeId TypeId { get; }
+        public ExpandedNodeId? TypeId { get; }
 
         public BodyType BodyType { get; }
     }

--- a/UaClient/ServiceModel/Ua/LocalizedText.cs
+++ b/UaClient/ServiceModel/Ua/LocalizedText.cs
@@ -3,6 +3,7 @@
 
 namespace Workstation.ServiceModel.Ua
 {
+    #nullable enable
     public sealed class LocalizedText
     {
         /// <summary>
@@ -10,27 +11,27 @@ namespace Workstation.ServiceModel.Ua
         /// </summary>
         /// <param name="text">The text in the specified locale.</param>
         /// <param name="locale">The locale.</param>
-        public LocalizedText(string text, string locale = "")
+        public LocalizedText(string? text, string? locale = "")
         {
             this.Locale = locale;
             this.Text = text;
         }
 
-        public string Text { get; }
+        public string? Text { get; }
 
-        public string Locale { get; }
+        public string? Locale { get; }
 
-        public static implicit operator LocalizedText(string a)
+        public static implicit operator LocalizedText(string? a)
         {
             return new LocalizedText(a);
         }
 
-        public static implicit operator string(LocalizedText a)
+        public static implicit operator string?(LocalizedText? a)
         {
             return a?.Text;
         }
 
-        public static bool operator ==(LocalizedText a, LocalizedText b)
+        public static bool operator ==(LocalizedText? a, LocalizedText? b)
         {
             if (ReferenceEquals(a, b))
             {
@@ -45,12 +46,12 @@ namespace Workstation.ServiceModel.Ua
             return (a.Text == b.Text) && (a.Locale == b.Locale);
         }
 
-        public static bool operator !=(LocalizedText a, LocalizedText b)
+        public static bool operator !=(LocalizedText? a, LocalizedText? b)
         {
             return !(a == b);
         }
 
-        public override bool Equals(object o)
+        public override bool Equals(object? o)
         {
             if (o is LocalizedText)
             {
@@ -60,7 +61,7 @@ namespace Workstation.ServiceModel.Ua
             return false;
         }
 
-        public bool Equals(LocalizedText that)
+        public bool Equals(LocalizedText? that)
         {
             return this == that;
         }
@@ -72,7 +73,7 @@ namespace Workstation.ServiceModel.Ua
             return result;
         }
 
-        public override string ToString()
+        public override string? ToString()
         {
             return this.Text;
         }

--- a/UaClient/ServiceModel/Ua/NodeId.cs
+++ b/UaClient/ServiceModel/Ua/NodeId.cs
@@ -3,9 +3,12 @@
 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
 using System.Linq;
 using System.Text;
+
+#nullable enable
 
 namespace Workstation.ServiceModel.Ua
 {
@@ -82,7 +85,7 @@ namespace Workstation.ServiceModel.Ua
 
         public IdType IdType { get; }
 
-        public static bool operator ==(NodeId a, NodeId b)
+        public static bool operator ==(NodeId? a, NodeId? b)
         {
             if (ReferenceEquals(a, b))
             {
@@ -113,7 +116,7 @@ namespace Workstation.ServiceModel.Ua
             }
         }
 
-        public static bool operator !=(NodeId a, NodeId b)
+        public static bool operator !=(NodeId? a, NodeId? b)
         {
             return !(a == b);
         }
@@ -123,7 +126,7 @@ namespace Workstation.ServiceModel.Ua
             return (nodeId == null) || nodeId == Null;
         }
 
-        public static ExpandedNodeId ToExpandedNodeId(NodeId value, IList<string> namespaceUris)
+        public static ExpandedNodeId ToExpandedNodeId(NodeId value, IList<string>? namespaceUris)
         {
             if (ReferenceEquals(value, null))
             {
@@ -131,10 +134,9 @@ namespace Workstation.ServiceModel.Ua
             }
 
             ushort ns = value.NamespaceIndex;
-            string nsu = null;
             if (namespaceUris != null && ns > 0 && ns < namespaceUris.Count)
             {
-                nsu = namespaceUris[ns];
+                var nsu = namespaceUris[ns];
 
                 switch (value.IdType)
                 {
@@ -158,7 +160,7 @@ namespace Workstation.ServiceModel.Ua
             return new ExpandedNodeId(value);
         }
 
-        public static bool TryParse(string s, out NodeId value)
+        public static bool TryParse(string s, [NotNullWhen(returnValue: true)] out NodeId value)
         {
             try
             {
@@ -219,7 +221,7 @@ namespace Workstation.ServiceModel.Ua
             return value;
         }
 
-        public override bool Equals(object o)
+        public override bool Equals(object? o)
         {
             if (o is NodeId)
             {
@@ -229,7 +231,7 @@ namespace Workstation.ServiceModel.Ua
             return false;
         }
 
-        public bool Equals(NodeId that)
+        public bool Equals(NodeId? that)
         {
             return this == that;
         }

--- a/UaClient/Workstation.UaClient.csproj
+++ b/UaClient/Workstation.UaClient.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFrameworks>netstandard2.0;netcoreapp3.0</TargetFrameworks>
     <AssemblyName>Workstation.UaClient</AssemblyName>
     <RootNamespace>Workstation</RootNamespace>
     <Version>2.5.0</Version>
@@ -22,7 +22,7 @@
     <IncludeSymbols>true</IncludeSymbols>
     <GenerateDocumentationFile Condition=" '$(Configuration)' == 'Release' ">true</GenerateDocumentationFile>
     <PackageLicenseFile>LICENSE.txt</PackageLicenseFile>
-    <LangVersion>latest</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
While it is possible to use the NRTs with netstandard 2.0, it does not provide the very usefull attributes like `NotNullWhenAttribute`. It seems the only way to get it compile for netstandard 2.0 is to add those attributes to the project. This takes away my enthusiasm a little bit. Nonetheless I think it 'd still be useful to keep on converting the API.