### PR TITLE
[WIP] Add nullable annotation to Variant

### DIFF
--- a/UaClient.UnitTests/UnitTests/VariantTests.cs
+++ b/UaClient.UnitTests/UnitTests/VariantTests.cs
@@ -108,6 +108,20 @@ namespace Workstation.UaClient.UnitTests
                 .Which
                 .Should().Be(length);
         }
+        
+        [Fact]
+        public void CreateArrayNull()
+        {
+            var val = default(Array);
+            var v = new Variant(val);
+
+            v.Value
+                .Should().Be(val);
+            v.Type
+                .Should().Be(VariantType.Null);
+            v.ArrayDimensions
+                .Should().BeNull();
+        }
 
         [Fact]
         public void CreateArrayObjectEncodeable()
@@ -203,6 +217,20 @@ namespace Workstation.UaClient.UnitTests
                 .Which
                 .Should().Be(val.Length);
         }
+
+        [Fact]
+        public void CreateBooleanArrayNull()
+        {
+            var val = default(bool[]);
+            var v = new Variant(val);
+
+            v.Value
+                .Should().Be(val);
+            v.Type
+                .Should().Be(VariantType.Null);
+            v.ArrayDimensions
+                .Should().BeNull();
+        }
         
         [Fact]
         public void ImplicitCreateBooleanArray()
@@ -277,6 +305,21 @@ namespace Workstation.UaClient.UnitTests
                 .Which
                 .Should().Be(val.Length);
         }
+        
+        [Fact]
+        public void CreateSByteArrayNull()
+        {
+            var val = default(sbyte[]);
+            var v = new Variant(val);
+
+            v.Value
+                .Should().Be(val);
+            v.Type
+                .Should().Be(VariantType.Null);
+            v.ArrayDimensions
+                .Should().BeNull();
+        }
+        
         
         [Fact]
         public void ImplicitCreateSByteArray()
@@ -389,6 +432,20 @@ namespace Workstation.UaClient.UnitTests
         }
         
         [Fact]
+        public void CreateShortArrayNull()
+        {
+            var val = default(short[]);
+            var v = new Variant(val);
+
+            v.Value
+                .Should().Be(val);
+            v.Type
+                .Should().Be(VariantType.Null);
+            v.ArrayDimensions
+                .Should().BeNull();
+        }
+        
+        [Fact]
         public void ImplicitCreateShortArray()
         {
             var val = new short[] { 2, 3, 4, 0 };
@@ -460,6 +517,20 @@ namespace Workstation.UaClient.UnitTests
                 .Should().ContainSingle()
                 .Which
                 .Should().Be(val.Length);
+        }
+        
+        [Fact]
+        public void CreateUShortArrayNull()
+        {
+            var val = default(ushort[]);
+            var v = new Variant(val);
+
+            v.Value
+                .Should().Be(val);
+            v.Type
+                .Should().Be(VariantType.Null);
+            v.ArrayDimensions
+                .Should().BeNull();
         }
         
         [Fact]
@@ -537,6 +608,20 @@ namespace Workstation.UaClient.UnitTests
         }
         
         [Fact]
+        public void CreateIntArrayNull()
+        {
+            var val = default(int[]);
+            var v = new Variant(val);
+
+            v.Value
+                .Should().Be(val);
+            v.Type
+                .Should().Be(VariantType.Null);
+            v.ArrayDimensions
+                .Should().BeNull();
+        }
+        
+        [Fact]
         public void ImplicitCreateIntArray()
         {
             var val = new int[] { 2, 3, 4, 0 };
@@ -608,6 +693,20 @@ namespace Workstation.UaClient.UnitTests
                 .Should().ContainSingle()
                 .Which
                 .Should().Be(val.Length);
+        }
+        
+        [Fact]
+        public void CreateUIntArrayNull()
+        {
+            var val = default(uint[]);
+            var v = new Variant(val);
+
+            v.Value
+                .Should().Be(val);
+            v.Type
+                .Should().Be(VariantType.Null);
+            v.ArrayDimensions
+                .Should().BeNull();
         }
         
         [Fact]
@@ -683,7 +782,21 @@ namespace Workstation.UaClient.UnitTests
                 .Which
                 .Should().Be(val.Length);
         }
+        
+        [Fact]
+        public void CreateLongArrayNull()
+        {
+            var val = default(long[]);
+            var v = new Variant(val);
 
+            v.Value
+                .Should().Be(val);
+            v.Type
+                .Should().Be(VariantType.Null);
+            v.ArrayDimensions
+                .Should().BeNull();
+        }
+        
         [Fact]
         public void ImplicitCreateLongArray()
         {
@@ -757,7 +870,21 @@ namespace Workstation.UaClient.UnitTests
                 .Which
                 .Should().Be(val.Length);
         }
+        
+        [Fact]
+        public void CreateULongArrayNull()
+        {
+            var val = default(ulong[]);
+            var v = new Variant(val);
 
+            v.Value
+                .Should().Be(val);
+            v.Type
+                .Should().Be(VariantType.Null);
+            v.ArrayDimensions
+                .Should().BeNull();
+        }
+        
         [Fact]
         public void ImplicitCreateULongArray()
         {
@@ -831,7 +958,21 @@ namespace Workstation.UaClient.UnitTests
                 .Which
                 .Should().Be(val.Length);
         }
+        
+        [Fact]
+        public void CreateFloatArrayNull()
+        {
+            var val = default(float[]);
+            var v = new Variant(val);
 
+            v.Value
+                .Should().Be(val);
+            v.Type
+                .Should().Be(VariantType.Null);
+            v.ArrayDimensions
+                .Should().BeNull();
+        }
+        
         [Fact]
         public void ImplicitCreateFloatArray()
         {
@@ -905,6 +1046,20 @@ namespace Workstation.UaClient.UnitTests
                 .Which
                 .Should().Be(val.Length);
         }
+        
+        [Fact]
+        public void CreateDoubleArrayNull()
+        {
+            var val = default(double[]);
+            var v = new Variant(val);
+
+            v.Value
+                .Should().Be(val);
+            v.Type
+                .Should().Be(VariantType.Null);
+            v.ArrayDimensions
+                .Should().BeNull();
+        }
 
         [Fact]
         public void ImplicitCreateDoubleArray()
@@ -938,6 +1093,20 @@ namespace Workstation.UaClient.UnitTests
                 .Should().Be(val);
             v.Type
                 .Should().Be(VariantType.String);
+            v.ArrayDimensions
+                .Should().BeNull();
+        }
+        
+        [Fact]
+        public void CreateStringNull()
+        {
+            var val = default(string);
+            var v = new Variant(val);
+
+            v.Value
+                .Should().Be(val);
+            v.Type
+                .Should().Be(VariantType.Null);
             v.ArrayDimensions
                 .Should().BeNull();
         }
@@ -978,6 +1147,20 @@ namespace Workstation.UaClient.UnitTests
                 .Should().ContainSingle()
                 .Which
                 .Should().Be(val.Length);
+        }
+        
+        [Fact]
+        public void CreateStringArrayNull()
+        {
+            var val = default(string[]);
+            var v = new Variant(val);
+
+            v.Value
+                .Should().Be(val);
+            v.Type
+                .Should().Be(VariantType.Null);
+            v.ArrayDimensions
+                .Should().BeNull();
         }
         
         [Fact]
@@ -1053,6 +1236,20 @@ namespace Workstation.UaClient.UnitTests
                 .Which
                 .Should().Be(val.Length);
         }
+        
+        [Fact]
+        public void CreateDateTimeArrayNull()
+        {
+            var val = default(DateTime[]);
+            var v = new Variant(val);
+
+            v.Value
+                .Should().Be(val);
+            v.Type
+                .Should().Be(VariantType.Null);
+            v.ArrayDimensions
+                .Should().BeNull();
+        }
 
         [Fact]
         public void ImplicitCreateDateTimeArray()
@@ -1127,6 +1324,20 @@ namespace Workstation.UaClient.UnitTests
                 .Which
                 .Should().Be(val.Length);
         }
+        
+        [Fact]
+        public void CreateGuidArrayNull()
+        {
+            var val = default(Guid[]);
+            var v = new Variant(val);
+
+            v.Value
+                .Should().Be(val);
+            v.Type
+                .Should().Be(VariantType.Null);
+            v.ArrayDimensions
+                .Should().BeNull();
+        }
 
         [Fact]
         public void ImplicitCreateGuidArray()
@@ -1160,6 +1371,20 @@ namespace Workstation.UaClient.UnitTests
                 .Should().Be(val);
             v.Type
                 .Should().Be(VariantType.ByteString);
+            v.ArrayDimensions
+                .Should().BeNull();
+        }
+        
+        [Fact]
+        public void CreateByteStringNull()
+        {
+            var val = default(byte[]);
+            var v = new Variant(val);
+
+            v.Value
+                .Should().Be(val);
+            v.Type
+                .Should().Be(VariantType.Null);
             v.ArrayDimensions
                 .Should().BeNull();
         }
@@ -1201,6 +1426,20 @@ namespace Workstation.UaClient.UnitTests
                 .Which
                 .Should().Be(val.Length);
         }
+        
+        [Fact]
+        public void CreateByteStringArrayNull()
+        {
+            var val = default(byte[][]);
+            var v = new Variant(val);
+
+            v.Value
+                .Should().Be(val);
+            v.Type
+                .Should().Be(VariantType.Null);
+            v.ArrayDimensions
+                .Should().BeNull();
+        }
 
         [Fact]
         public void ImplicitCreateByteStringArray()
@@ -1234,6 +1473,20 @@ namespace Workstation.UaClient.UnitTests
                 .Should().Be(val);
             v.Type
                 .Should().Be(VariantType.XmlElement);
+            v.ArrayDimensions
+                .Should().BeNull();
+        }
+        
+        [Fact]
+        public void CreateXElementNull()
+        {
+            var val = default(XElement);
+            var v = new Variant(val);
+
+            v.Value
+                .Should().Be(val);
+            v.Type
+                .Should().Be(VariantType.Null);
             v.ArrayDimensions
                 .Should().BeNull();
         }
@@ -1277,6 +1530,20 @@ namespace Workstation.UaClient.UnitTests
         }
         
         [Fact]
+        public void CreateXElementArrayNull()
+        {
+            var val = default(XElement[]);
+            var v = new Variant(val);
+
+            v.Value
+                .Should().Be(val);
+            v.Type
+                .Should().Be(VariantType.Null);
+            v.ArrayDimensions
+                .Should().BeNull();
+        }
+        
+        [Fact]
         public void ImplicitCreateXElementArray()
         {
             var val = new[] { XElement.Parse(@"<Item AttributeA=""A"" AttributeB=""B"" />") };
@@ -1308,6 +1575,20 @@ namespace Workstation.UaClient.UnitTests
                 .Should().Be(val);
             v.Type
                 .Should().Be(VariantType.NodeId);
+            v.ArrayDimensions
+                .Should().BeNull();
+        }
+        
+        [Fact]
+        public void CreateNodeIdNull()
+        {
+            var val = default(NodeId);
+            var v = new Variant(val);
+
+            v.Value
+                .Should().Be(val);
+            v.Type
+                .Should().Be(VariantType.Null);
             v.ArrayDimensions
                 .Should().BeNull();
         }
@@ -1349,6 +1630,20 @@ namespace Workstation.UaClient.UnitTests
                 .Which
                 .Should().Be(val.Length);
         }
+        
+        [Fact]
+        public void CreateNodeIdArrayNull()
+        {
+            var val = default(NodeId[]);
+            var v = new Variant(val);
+
+            v.Value
+                .Should().Be(val);
+            v.Type
+                .Should().Be(VariantType.Null);
+            v.ArrayDimensions
+                .Should().BeNull();
+        }
 
         [Fact]
         public void ImplicitCreateNodeIdArray()
@@ -1382,6 +1677,20 @@ namespace Workstation.UaClient.UnitTests
                 .Should().Be(val);
             v.Type
                 .Should().Be(VariantType.ExpandedNodeId);
+            v.ArrayDimensions
+                .Should().BeNull();
+        }
+        
+        [Fact]
+        public void CreateExpandedNodeIdNull()
+        {
+            var val = default(ExpandedNodeId);
+            var v = new Variant(val);
+
+            v.Value
+                .Should().Be(val);
+            v.Type
+                .Should().Be(VariantType.Null);
             v.ArrayDimensions
                 .Should().BeNull();
         }
@@ -1422,6 +1731,20 @@ namespace Workstation.UaClient.UnitTests
                 .Should().ContainSingle()
                 .Which
                 .Should().Be(val.Length);
+        }
+        
+        [Fact]
+        public void CreateExpandedNodeIdArrayNull()
+        {
+            var val = default(ExpandedNodeId[]);
+            var v = new Variant(val);
+
+            v.Value
+                .Should().Be(val);
+            v.Type
+                .Should().Be(VariantType.Null);
+            v.ArrayDimensions
+                .Should().BeNull();
         }
 
         [Fact]
@@ -1497,6 +1820,20 @@ namespace Workstation.UaClient.UnitTests
                 .Which
                 .Should().Be(val.Length);
         }
+        
+        [Fact]
+        public void CreateStatusCodeArrayNull()
+        {
+            var val = default(StatusCode[]);
+            var v = new Variant(val);
+
+            v.Value
+                .Should().Be(val);
+            v.Type
+                .Should().Be(VariantType.Null);
+            v.ArrayDimensions
+                .Should().BeNull();
+        }
 
         [Fact]
         public void ImplicitCreateStatusCodeArray()
@@ -1530,6 +1867,20 @@ namespace Workstation.UaClient.UnitTests
                 .Should().Be(val);
             v.Type
                 .Should().Be(VariantType.QualifiedName);
+            v.ArrayDimensions
+                .Should().BeNull();
+        }
+        
+        [Fact]
+        public void CreateQualifiedNameNull()
+        {
+            var val = default(QualifiedName);
+            var v = new Variant(val);
+
+            v.Value
+                .Should().Be(val);
+            v.Type
+                .Should().Be(VariantType.Null);
             v.ArrayDimensions
                 .Should().BeNull();
         }
@@ -1573,6 +1924,20 @@ namespace Workstation.UaClient.UnitTests
         }
         
         [Fact]
+        public void CreateQualifiedNameArrayNull()
+        {
+            var val = default(QualifiedName[]);
+            var v = new Variant(val);
+
+            v.Value
+                .Should().Be(val);
+            v.Type
+                .Should().Be(VariantType.Null);
+            v.ArrayDimensions
+                .Should().BeNull();
+        }
+
+        [Fact]
         public void ImplicitCreateQualifiedNameArray()
         {
             var val = new[] { new QualifiedName("name") };
@@ -1604,6 +1969,20 @@ namespace Workstation.UaClient.UnitTests
                 .Should().Be(val);
             v.Type
                 .Should().Be(VariantType.LocalizedText);
+            v.ArrayDimensions
+                .Should().BeNull();
+        }
+        
+        [Fact]
+        public void CreateLocalizedTextNull()
+        {
+            var val = default(LocalizedText);
+            var v = new Variant(val);
+
+            v.Value
+                .Should().Be(val);
+            v.Type
+                .Should().Be(VariantType.Null);
             v.ArrayDimensions
                 .Should().BeNull();
         }
@@ -1645,6 +2024,20 @@ namespace Workstation.UaClient.UnitTests
                 .Which
                 .Should().Be(val.Length);
         }
+        
+        [Fact]
+        public void CreateLocalizedTextArrayNull()
+        {
+            var val = default(LocalizedText[]);
+            var v = new Variant(val);
+
+            v.Value
+                .Should().Be(val);
+            v.Type
+                .Should().Be(VariantType.Null);
+            v.ArrayDimensions
+                .Should().BeNull();
+        }
 
         [Fact]
         public void ImplicitCreateLocalizedTextArray()
@@ -1678,6 +2071,20 @@ namespace Workstation.UaClient.UnitTests
                 .Should().Be(val);
             v.Type
                 .Should().Be(VariantType.ExtensionObject);
+            v.ArrayDimensions
+                .Should().BeNull();
+        }
+        
+        [Fact]
+        public void CreateExtensionObjectNull()
+        {
+            var val = default(ExtensionObject);
+            var v = new Variant(val);
+
+            v.Value
+                .Should().Be(val);
+            v.Type
+                .Should().Be(VariantType.Null);
             v.ArrayDimensions
                 .Should().BeNull();
         }
@@ -1721,6 +2128,20 @@ namespace Workstation.UaClient.UnitTests
         }
         
         [Fact]
+        public void CreateExtensionObjectArrayNull()
+        {
+            var val = default(ExtensionObject[]);
+            var v = new Variant(val);
+
+            v.Value
+                .Should().Be(val);
+            v.Type
+                .Should().Be(VariantType.Null);
+            v.ArrayDimensions
+                .Should().BeNull();
+        }
+        
+        [Fact]
         public void ImplicitCreateExtensionObjectArray()
         {
             var val = new[] { new ExtensionObject(null) };
@@ -1755,6 +2176,20 @@ namespace Workstation.UaClient.UnitTests
             v.ArrayDimensions
                 .Should().BeNull();
         }
+        
+        [Fact]
+        public void CreateEncodeableNull()
+        {
+            var val = default(ReadRequest);
+            var v = new Variant(val);
+
+            v.Value
+                .Should().Be(val);
+            v.Type
+                .Should().Be(VariantType.Null);
+            v.ArrayDimensions
+                .Should().BeNull();
+        }
 
         [Fact]
         public void CreateEncodeableArray()
@@ -1770,6 +2205,20 @@ namespace Workstation.UaClient.UnitTests
                 .Should().ContainSingle()
                 .Which
                 .Should().Be(val.Length);
+        }
+        
+        [Fact]
+        public void CreateEncodeableArrayNull()
+        {
+            var val = default(ReadRequest[]);
+            var v = new Variant(val);
+
+            v.Value
+                .Should().Be(val);
+            v.Type
+                .Should().Be(VariantType.Null);
+            v.ArrayDimensions
+                .Should().BeNull();
         }
 
         enum TestEnumeration
@@ -1806,6 +2255,34 @@ namespace Workstation.UaClient.UnitTests
                 .Should().ContainSingle()
                 .Which
                 .Should().Be(val.Length);
+        }
+        
+        [Fact]
+        public void CreateEnumArrayNull()
+        {
+            var val = default(Enum[]);
+            var v = new Variant(val);
+
+            v.Value
+                .Should().Be(val);
+            v.Type
+                .Should().Be(VariantType.Null);
+            v.ArrayDimensions
+                .Should().BeNull();
+        }
+        
+        [Fact]
+        public void CreateVariantArrayNull()
+        {
+            var val = default(Variant[]);
+            var v = new Variant(val);
+
+            v.Value
+                .Should().Be(val);
+            v.Type
+                .Should().Be(VariantType.Null);
+            v.ArrayDimensions
+                .Should().BeNull();
         }
     }
 }

--- a/UaClient/ServiceModel/Ua/Variant.cs
+++ b/UaClient/ServiceModel/Ua/Variant.cs
@@ -256,6 +256,14 @@ namespace Workstation.ServiceModel.Ua
 
         public Variant(string? value)
         {
+            if (value is null)
+            {
+                this.Value = null;
+                this.Type = VariantType.Null;
+                this.ArrayDimensions = null;
+                return;
+            }
+
             this.Value = value;
             this.Type = VariantType.String;
             this.ArrayDimensions = null;
@@ -277,6 +285,14 @@ namespace Workstation.ServiceModel.Ua
 
         public Variant(byte[]? value)
         {
+            if (value is null)
+            {
+                this.Value = null;
+                this.Type = VariantType.Null;
+                this.ArrayDimensions = null;
+                return;
+            }
+
             this.Value = value;
             this.Type = VariantType.ByteString;
             this.ArrayDimensions = null;
@@ -284,6 +300,14 @@ namespace Workstation.ServiceModel.Ua
 
         public Variant(XElement? value)
         {
+            if (value is null)
+            {
+                this.Value = null;
+                this.Type = VariantType.Null;
+                this.ArrayDimensions = null;
+                return;
+            }
+
             this.Value = value;
             this.Type = VariantType.XmlElement;
             this.ArrayDimensions = null;
@@ -291,6 +315,14 @@ namespace Workstation.ServiceModel.Ua
 
         public Variant(NodeId? value)
         {
+            if (value is null)
+            {
+                this.Value = null;
+                this.Type = VariantType.Null;
+                this.ArrayDimensions = null;
+                return;
+            }
+
             this.Value = value;
             this.Type = VariantType.NodeId;
             this.ArrayDimensions = null;
@@ -298,6 +330,14 @@ namespace Workstation.ServiceModel.Ua
 
         public Variant(ExpandedNodeId? value)
         {
+            if (value is null)
+            {
+                this.Value = null;
+                this.Type = VariantType.Null;
+                this.ArrayDimensions = null;
+                return;
+            }
+
             this.Value = value;
             this.Type = VariantType.ExpandedNodeId;
             this.ArrayDimensions = null;
@@ -312,6 +352,14 @@ namespace Workstation.ServiceModel.Ua
 
         public Variant(QualifiedName? value)
         {
+            if (value is null)
+            {
+                this.Value = null;
+                this.Type = VariantType.Null;
+                this.ArrayDimensions = null;
+                return;
+            }
+
             this.Value = value;
             this.Type = VariantType.QualifiedName;
             this.ArrayDimensions = null;
@@ -319,6 +367,14 @@ namespace Workstation.ServiceModel.Ua
 
         public Variant(LocalizedText? value)
         {
+            if (value is null)
+            {
+                this.Value = null;
+                this.Type = VariantType.Null;
+                this.ArrayDimensions = null;
+                return;
+            }
+
             this.Value = value;
             this.Type = VariantType.LocalizedText;
             this.ArrayDimensions = null;
@@ -326,6 +382,14 @@ namespace Workstation.ServiceModel.Ua
 
         public Variant(ExtensionObject? value)
         {
+            if (value is null)
+            {
+                this.Value = null;
+                this.Type = VariantType.Null;
+                this.ArrayDimensions = null;
+                return;
+            }
+
             this.Value = value;
             this.Type = VariantType.ExtensionObject;
             this.ArrayDimensions = null;
@@ -333,6 +397,14 @@ namespace Workstation.ServiceModel.Ua
 
         public Variant(IEncodable? value)
         {
+            if (value is null)
+            {
+                this.Value = null;
+                this.Type = VariantType.Null;
+                this.ArrayDimensions = null;
+                return;
+            }
+
             this.Value = new ExtensionObject(value);
             this.Type = VariantType.ExtensionObject;
             this.ArrayDimensions = null;
@@ -347,7 +419,14 @@ namespace Workstation.ServiceModel.Ua
 
         public Variant(bool[]? value)
         {
-            // REVIEW: Should we throw on null?
+            if (value is null)
+            {
+                this.Value = null;
+                this.Type = VariantType.Null;
+                this.ArrayDimensions = null;
+                return;
+            }
+
             this.Value = value;
             this.Type = VariantType.Boolean;
             this.ArrayDimensions = new int[value.Rank];
@@ -357,8 +436,16 @@ namespace Workstation.ServiceModel.Ua
             }
         }
 
-        public Variant(sbyte[] value)
+        public Variant(sbyte[]? value)
         {
+            if (value is null)
+            {
+                this.Value = null;
+                this.Type = VariantType.Null;
+                this.ArrayDimensions = null;
+                return;
+            }
+
             this.Value = value;
             this.Type = VariantType.SByte;
             this.ArrayDimensions = new int[value.Rank];
@@ -368,8 +455,16 @@ namespace Workstation.ServiceModel.Ua
             }
         }
 
-        public Variant(short[] value)
+        public Variant(short[]? value)
         {
+            if (value is null)
+            {
+                this.Value = null;
+                this.Type = VariantType.Null;
+                this.ArrayDimensions = null;
+                return;
+            }
+
             this.Value = value;
             this.Type = VariantType.Int16;
             this.ArrayDimensions = new int[value.Rank];
@@ -379,8 +474,16 @@ namespace Workstation.ServiceModel.Ua
             }
         }
 
-        public Variant(ushort[] value)
+        public Variant(ushort[]? value)
         {
+            if (value is null)
+            {
+                this.Value = null;
+                this.Type = VariantType.Null;
+                this.ArrayDimensions = null;
+                return;
+            }
+
             this.Value = value;
             this.Type = VariantType.UInt16;
             this.ArrayDimensions = new int[value.Rank];
@@ -390,8 +493,16 @@ namespace Workstation.ServiceModel.Ua
             }
         }
 
-        public Variant(int[] value)
+        public Variant(int[]? value)
         {
+            if (value is null)
+            {
+                this.Value = null;
+                this.Type = VariantType.Null;
+                this.ArrayDimensions = null;
+                return;
+            }
+
             this.Value = value;
             this.Type = VariantType.Int32;
             this.ArrayDimensions = new int[value.Rank];
@@ -401,8 +512,16 @@ namespace Workstation.ServiceModel.Ua
             }
         }
 
-        public Variant(uint[] value)
+        public Variant(uint[]? value)
         {
+            if (value is null)
+            {
+                this.Value = null;
+                this.Type = VariantType.Null;
+                this.ArrayDimensions = null;
+                return;
+            }
+
             this.Value = value;
             this.Type = VariantType.UInt32;
             this.ArrayDimensions = new int[value.Rank];
@@ -412,8 +531,16 @@ namespace Workstation.ServiceModel.Ua
             }
         }
 
-        public Variant(long[] value)
+        public Variant(long[]? value)
         {
+            if (value is null)
+            {
+                this.Value = null;
+                this.Type = VariantType.Null;
+                this.ArrayDimensions = null;
+                return;
+            }
+
             this.Value = value;
             this.Type = VariantType.Int64;
             this.ArrayDimensions = new int[value.Rank];
@@ -423,8 +550,16 @@ namespace Workstation.ServiceModel.Ua
             }
         }
 
-        public Variant(ulong[] value)
+        public Variant(ulong[]? value)
         {
+            if (value is null)
+            {
+                this.Value = null;
+                this.Type = VariantType.Null;
+                this.ArrayDimensions = null;
+                return;
+            }
+
             this.Value = value;
             this.Type = VariantType.UInt64;
             this.ArrayDimensions = new int[value.Rank];
@@ -434,8 +569,16 @@ namespace Workstation.ServiceModel.Ua
             }
         }
 
-        public Variant(float[] value)
+        public Variant(float[]? value)
         {
+            if (value is null)
+            {
+                this.Value = null;
+                this.Type = VariantType.Null;
+                this.ArrayDimensions = null;
+                return;
+            }
+
             this.Value = value;
             this.Type = VariantType.Float;
             this.ArrayDimensions = new int[value.Rank];
@@ -445,8 +588,16 @@ namespace Workstation.ServiceModel.Ua
             }
         }
 
-        public Variant(double[] value)
+        public Variant(double[]? value)
         {
+            if (value is null)
+            {
+                this.Value = null;
+                this.Type = VariantType.Null;
+                this.ArrayDimensions = null;
+                return;
+            }
+
             this.Value = value;
             this.Type = VariantType.Double;
             this.ArrayDimensions = new int[value.Rank];
@@ -456,8 +607,16 @@ namespace Workstation.ServiceModel.Ua
             }
         }
 
-        public Variant(string[] value)
+        public Variant(string[]? value)
         {
+            if (value is null)
+            {
+                this.Value = null;
+                this.Type = VariantType.Null;
+                this.ArrayDimensions = null;
+                return;
+            }
+
             this.Value = value;
             this.Type = VariantType.String;
             this.ArrayDimensions = new int[value.Rank];
@@ -467,8 +626,16 @@ namespace Workstation.ServiceModel.Ua
             }
         }
 
-        public Variant(DateTime[] value)
+        public Variant(DateTime[]? value)
         {
+            if (value is null)
+            {
+                this.Value = null;
+                this.Type = VariantType.Null;
+                this.ArrayDimensions = null;
+                return;
+            }
+
             this.Value = value;
             this.Type = VariantType.DateTime;
             this.ArrayDimensions = new int[value.Rank];
@@ -478,8 +645,16 @@ namespace Workstation.ServiceModel.Ua
             }
         }
 
-        public Variant(Guid[] value)
+        public Variant(Guid[]? value)
         {
+            if (value is null)
+            {
+                this.Value = null;
+                this.Type = VariantType.Null;
+                this.ArrayDimensions = null;
+                return;
+            }
+
             this.Value = value;
             this.Type = VariantType.Guid;
             this.ArrayDimensions = new int[value.Rank];
@@ -489,8 +664,16 @@ namespace Workstation.ServiceModel.Ua
             }
         }
 
-        public Variant(byte[][] value)
+        public Variant(byte[][]? value)
         {
+            if (value is null)
+            {
+                this.Value = null;
+                this.Type = VariantType.Null;
+                this.ArrayDimensions = null;
+                return;
+            }
+
             this.Value = value;
             this.Type = VariantType.ByteString;
             this.ArrayDimensions = new int[value.Rank];
@@ -500,8 +683,16 @@ namespace Workstation.ServiceModel.Ua
             }
         }
 
-        public Variant(XElement[] value)
+        public Variant(XElement[]? value)
         {
+            if (value is null)
+            {
+                this.Value = null;
+                this.Type = VariantType.Null;
+                this.ArrayDimensions = null;
+                return;
+            }
+
             this.Value = value;
             this.Type = VariantType.XmlElement;
             this.ArrayDimensions = new int[value.Rank];
@@ -511,8 +702,16 @@ namespace Workstation.ServiceModel.Ua
             }
         }
 
-        public Variant(NodeId[] value)
+        public Variant(NodeId[]? value)
         {
+            if (value is null)
+            {
+                this.Value = null;
+                this.Type = VariantType.Null;
+                this.ArrayDimensions = null;
+                return;
+            }
+
             this.Value = value;
             this.Type = VariantType.NodeId;
             this.ArrayDimensions = new int[value.Rank];
@@ -522,8 +721,16 @@ namespace Workstation.ServiceModel.Ua
             }
         }
 
-        public Variant(ExpandedNodeId[] value)
+        public Variant(ExpandedNodeId[]? value)
         {
+            if (value is null)
+            {
+                this.Value = null;
+                this.Type = VariantType.Null;
+                this.ArrayDimensions = null;
+                return;
+            }
+
             this.Value = value;
             this.Type = VariantType.ExpandedNodeId;
             this.ArrayDimensions = new int[value.Rank];
@@ -533,8 +740,16 @@ namespace Workstation.ServiceModel.Ua
             }
         }
 
-        public Variant(StatusCode[] value)
+        public Variant(StatusCode[]? value)
         {
+            if (value is null)
+            {
+                this.Value = null;
+                this.Type = VariantType.Null;
+                this.ArrayDimensions = null;
+                return;
+            }
+
             this.Value = value;
             this.Type = VariantType.StatusCode;
             this.ArrayDimensions = new int[value.Rank];
@@ -544,8 +759,16 @@ namespace Workstation.ServiceModel.Ua
             }
         }
 
-        public Variant(QualifiedName[] value)
+        public Variant(QualifiedName[]? value)
         {
+            if (value is null)
+            {
+                this.Value = null;
+                this.Type = VariantType.Null;
+                this.ArrayDimensions = null;
+                return;
+            }
+
             this.Value = value;
             this.Type = VariantType.QualifiedName;
             this.ArrayDimensions = new int[value.Rank];
@@ -555,8 +778,16 @@ namespace Workstation.ServiceModel.Ua
             }
         }
 
-        public Variant(LocalizedText[] value)
+        public Variant(LocalizedText[]? value)
         {
+            if (value is null)
+            {
+                this.Value = null;
+                this.Type = VariantType.Null;
+                this.ArrayDimensions = null;
+                return;
+            }
+
             this.Value = value;
             this.Type = VariantType.LocalizedText;
             this.ArrayDimensions = new int[value.Rank];
@@ -566,8 +797,16 @@ namespace Workstation.ServiceModel.Ua
             }
         }
 
-        public Variant(ExtensionObject[] value)
+        public Variant(ExtensionObject[]? value)
         {
+            if (value is null)
+            {
+                this.Value = null;
+                this.Type = VariantType.Null;
+                this.ArrayDimensions = null;
+                return;
+            }
+
             this.Value = value;
             this.Type = VariantType.ExtensionObject;
             this.ArrayDimensions = new int[value.Rank];
@@ -577,8 +816,16 @@ namespace Workstation.ServiceModel.Ua
             }
         }
 
-        public Variant(Variant[] value)
+        public Variant(Variant[]? value)
         {
+            if (value is null)
+            {
+                this.Value = null;
+                this.Type = VariantType.Null;
+                this.ArrayDimensions = null;
+                return;
+            }
+
             this.Value = value;
             this.Type = VariantType.Variant;
             this.ArrayDimensions = new int[value.Rank];
@@ -588,8 +835,16 @@ namespace Workstation.ServiceModel.Ua
             }
         }
 
-        public Variant(Enum[] value)
+        public Variant(Enum[]? value)
         {
+            if (value is null)
+            {
+                this.Value = null;
+                this.Type = VariantType.Null;
+                this.ArrayDimensions = null;
+                return;
+            }
+
             this.Value = value.Select(v => Convert.ToInt32(v, CultureInfo.InvariantCulture)).ToArray();
             this.Type = VariantType.Int32;
             this.ArrayDimensions = new int[value.Rank];
@@ -599,8 +854,16 @@ namespace Workstation.ServiceModel.Ua
             }
         }
 
-        public Variant(IEncodable[] value)
+        public Variant(IEncodable[]? value)
         {
+            if (value is null)
+            {
+                this.Value = null;
+                this.Type = VariantType.Null;
+                this.ArrayDimensions = null;
+                return;
+            }
+
             this.Value = value.Select(v => new ExtensionObject(v)).ToArray();
             this.Type = VariantType.ExtensionObject;
             this.ArrayDimensions = new int[value.Rank];
@@ -610,8 +873,16 @@ namespace Workstation.ServiceModel.Ua
             }
         }
 
-        public Variant(Array value)
+        public Variant(Array? value)
         {
+            if (value is null)
+            {
+                this.Value = null;
+                this.Type = VariantType.Null;
+                this.ArrayDimensions = null;
+                return;
+            }
+
             this.Value = value;
             VariantType varType;
             Type? elemType = value.GetType().GetElementType();
@@ -689,7 +960,7 @@ namespace Workstation.ServiceModel.Ua
             return new Variant(value);
         }
 
-        public static implicit operator Variant(string value)
+        public static implicit operator Variant(string? value)
         {
             return new Variant(value);
         }
@@ -704,22 +975,22 @@ namespace Workstation.ServiceModel.Ua
             return new Variant(value);
         }
 
-        public static implicit operator Variant(byte[] value)
+        public static implicit operator Variant(byte[]? value)
         {
             return new Variant(value);
         }
 
-        public static implicit operator Variant(XElement value)
+        public static implicit operator Variant(XElement? value)
         {
             return new Variant(value);
         }
 
-        public static implicit operator Variant(NodeId value)
+        public static implicit operator Variant(NodeId? value)
         {
             return new Variant(value);
         }
 
-        public static implicit operator Variant(ExpandedNodeId value)
+        public static implicit operator Variant(ExpandedNodeId? value)
         {
             return new Variant(value);
         }
@@ -729,122 +1000,122 @@ namespace Workstation.ServiceModel.Ua
             return new Variant(value);
         }
 
-        public static implicit operator Variant(QualifiedName value)
+        public static implicit operator Variant(QualifiedName? value)
         {
             return new Variant(value);
         }
 
-        public static implicit operator Variant(LocalizedText value)
+        public static implicit operator Variant(LocalizedText? value)
         {
             return new Variant(value);
         }
 
-        public static implicit operator Variant(ExtensionObject value)
+        public static implicit operator Variant(ExtensionObject? value)
         {
             return new Variant(value);
         }
 
-        public static implicit operator Variant(bool[] value)
+        public static implicit operator Variant(bool[]? value)
         {
             return new Variant(value);
         }
 
-        public static implicit operator Variant(sbyte[] value)
+        public static implicit operator Variant(sbyte[]? value)
         {
             return new Variant(value);
         }
 
-        public static implicit operator Variant(short[] value)
+        public static implicit operator Variant(short[]? value)
         {
             return new Variant(value);
         }
 
-        public static implicit operator Variant(ushort[] value)
+        public static implicit operator Variant(ushort[]? value)
         {
             return new Variant(value);
         }
 
-        public static implicit operator Variant(int[] value)
+        public static implicit operator Variant(int[]? value)
         {
             return new Variant(value);
         }
 
-        public static implicit operator Variant(uint[] value)
+        public static implicit operator Variant(uint[]? value)
         {
             return new Variant(value);
         }
 
-        public static implicit operator Variant(long[] value)
+        public static implicit operator Variant(long[]? value)
         {
             return new Variant(value);
         }
 
-        public static implicit operator Variant(ulong[] value)
+        public static implicit operator Variant(ulong[]? value)
         {
             return new Variant(value);
         }
 
-        public static implicit operator Variant(float[] value)
+        public static implicit operator Variant(float[]? value)
         {
             return new Variant(value);
         }
 
-        public static implicit operator Variant(double[] value)
+        public static implicit operator Variant(double[]? value)
         {
             return new Variant(value);
         }
 
-        public static implicit operator Variant(string[] value)
+        public static implicit operator Variant(string[]? value)
         {
             return new Variant(value);
         }
 
-        public static implicit operator Variant(DateTime[] value)
+        public static implicit operator Variant(DateTime[]? value)
         {
             return new Variant(value);
         }
 
-        public static implicit operator Variant(Guid[] value)
+        public static implicit operator Variant(Guid[]? value)
         {
             return new Variant(value);
         }
 
-        public static implicit operator Variant(byte[][] value)
+        public static implicit operator Variant(byte[][]? value)
         {
             return new Variant(value);
         }
 
-        public static implicit operator Variant(XElement[] value)
+        public static implicit operator Variant(XElement[]? value)
         {
             return new Variant(value);
         }
 
-        public static implicit operator Variant(NodeId[] value)
+        public static implicit operator Variant(NodeId[]? value)
         {
             return new Variant(value);
         }
 
-        public static implicit operator Variant(ExpandedNodeId[] value)
+        public static implicit operator Variant(ExpandedNodeId[]? value)
         {
             return new Variant(value);
         }
 
-        public static implicit operator Variant(StatusCode[] value)
+        public static implicit operator Variant(StatusCode[]? value)
         {
             return new Variant(value);
         }
 
-        public static implicit operator Variant(QualifiedName[] value)
+        public static implicit operator Variant(QualifiedName[]? value)
         {
             return new Variant(value);
         }
 
-        public static implicit operator Variant(LocalizedText[] value)
+        public static implicit operator Variant(LocalizedText[]? value)
         {
             return new Variant(value);
         }
 
-        public static implicit operator Variant(ExtensionObject[] value)
+        public static implicit operator Variant(ExtensionObject[]? value)
         {
             return new Variant(value);
         }
@@ -919,7 +1190,7 @@ namespace Workstation.ServiceModel.Ua
             return (Guid)value.Value!;
         }
 
-        public static explicit operator byte[]? (Variant value)
+        public static explicit operator byte[]?(Variant value)
         {
             return (byte[]?)value.Value;
         }
@@ -944,9 +1215,9 @@ namespace Workstation.ServiceModel.Ua
             return (StatusCode)value.Value!;
         }
 
-        public static explicit operator QualifiedName(Variant value)
+        public static explicit operator QualifiedName?(Variant value)
         {
-            return (QualifiedName)value.Value!;
+            return (QualifiedName?)value.Value;
         }
 
         public static explicit operator LocalizedText?(Variant value)
@@ -959,107 +1230,107 @@ namespace Workstation.ServiceModel.Ua
             return (ExtensionObject?)value.Value;
         }
 
-        public static explicit operator bool[]? (Variant value)
+        public static explicit operator bool[]?(Variant value)
         {
             return (bool[]?)value.Value;
         }
 
-        public static explicit operator sbyte[]? (Variant value)
+        public static explicit operator sbyte[]?(Variant value)
         {
             return (sbyte[]?)value.Value;
         }
 
-        public static explicit operator short[]? (Variant value)
+        public static explicit operator short[]?(Variant value)
         {
             return (short[]?)value.Value;
         }
 
-        public static explicit operator ushort[]? (Variant value)
+        public static explicit operator ushort[]?(Variant value)
         {
             return (ushort[]?)value.Value;
         }
 
-        public static explicit operator int[]? (Variant value)
+        public static explicit operator int[]?(Variant value)
         {
             return (int[]?)value.Value;
         }
 
-        public static explicit operator uint[]? (Variant value)
+        public static explicit operator uint[]?(Variant value)
         {
             return (uint[]?)value.Value;
         }
 
-        public static explicit operator long[]? (Variant value)
+        public static explicit operator long[]?(Variant value)
         {
             return (long[]?)value.Value;
         }
 
-        public static explicit operator ulong[]? (Variant value)
+        public static explicit operator ulong[]?(Variant value)
         {
             return (ulong[]?)value.Value;
         }
 
-        public static explicit operator float[]? (Variant value)
+        public static explicit operator float[]?(Variant value)
         {
             return (float[]?)value.Value;
         }
 
-        public static explicit operator double[]? (Variant value)
+        public static explicit operator double[]?(Variant value)
         {
             return (double[]?)value.Value;
         }
 
-        public static explicit operator string[]? (Variant value)
+        public static explicit operator string[]?(Variant value)
         {
             return (string[]?)value.Value;
         }
 
-        public static explicit operator DateTime[]? (Variant value)
+        public static explicit operator DateTime[]?(Variant value)
         {
             return (DateTime[]?)value.Value;
         }
 
-        public static explicit operator Guid[]? (Variant value)
+        public static explicit operator Guid[]?(Variant value)
         {
             return (Guid[]?)value.Value;
         }
 
-        public static explicit operator byte[][]? (Variant value)
+        public static explicit operator byte[][]?(Variant value)
         {
             return (byte[][]?)value.Value;
         }
 
-        public static explicit operator XElement[]? (Variant value)
+        public static explicit operator XElement[]?(Variant value)
         {
             return (XElement[]?)value.Value;
         }
 
-        public static explicit operator NodeId[]? (Variant value)
+        public static explicit operator NodeId[]?(Variant value)
         {
             return (NodeId[]?)value.Value;
         }
 
-        public static explicit operator ExpandedNodeId[]? (Variant value)
+        public static explicit operator ExpandedNodeId[]?(Variant value)
         {
             return (ExpandedNodeId[]?)value.Value;
         }
 
-        public static explicit operator StatusCode[]? (Variant value)
+        public static explicit operator StatusCode[]?(Variant value)
         {
             return (StatusCode[]?)value.Value;
         }
 
-        public static explicit operator QualifiedName[]? (Variant value)
+        public static explicit operator QualifiedName[]?(Variant value)
         {
             return (QualifiedName[]?)value.Value;
         }
 
-        public static explicit operator LocalizedText[]? (Variant value)
+        public static explicit operator LocalizedText[]?(Variant value)
         {
             return (LocalizedText[]?)value.Value;
         }
 
-        public static explicit operator ExtensionObject[]? (Variant value)
+        public static explicit operator ExtensionObject[]?(Variant value)
         {
             return (ExtensionObject[]?)value.Value;
         }

--- a/UaClient/ServiceModel/Ua/Variant.cs
+++ b/UaClient/ServiceModel/Ua/Variant.cs
@@ -8,6 +8,8 @@ using System.Linq;
 using System.Reflection;
 using System.Xml.Linq;
 
+#nullable enable
+
 namespace Workstation.ServiceModel.Ua
 {
     public enum VariantType
@@ -106,7 +108,7 @@ namespace Workstation.ServiceModel.Ua
             */
         };
 
-        public Variant(object value)
+        public Variant(object? value)
         {
             if (value == null)
             {
@@ -135,10 +137,9 @@ namespace Workstation.ServiceModel.Ua
                 return;
             }
 
-            var array = value as Array;
-            if (array != null)
+            if (value is Array array)
             {
-                Type elemType = value.GetType().GetElementType();
+                Type? elemType = array.GetType().GetElementType();
                 if (elemType == null)
                 {
                     throw new ArgumentOutOfRangeException(nameof(value), elemType, "Array element Type is unsupported.");
@@ -253,7 +254,7 @@ namespace Workstation.ServiceModel.Ua
             this.ArrayDimensions = null;
         }
 
-        public Variant(string value)
+        public Variant(string? value)
         {
             this.Value = value;
             this.Type = VariantType.String;
@@ -274,28 +275,28 @@ namespace Workstation.ServiceModel.Ua
             this.ArrayDimensions = null;
         }
 
-        public Variant(byte[] value)
+        public Variant(byte[]? value)
         {
             this.Value = value;
             this.Type = VariantType.ByteString;
             this.ArrayDimensions = null;
         }
 
-        public Variant(XElement value)
+        public Variant(XElement? value)
         {
             this.Value = value;
             this.Type = VariantType.XmlElement;
             this.ArrayDimensions = null;
         }
 
-        public Variant(NodeId value)
+        public Variant(NodeId? value)
         {
             this.Value = value;
             this.Type = VariantType.NodeId;
             this.ArrayDimensions = null;
         }
 
-        public Variant(ExpandedNodeId value)
+        public Variant(ExpandedNodeId? value)
         {
             this.Value = value;
             this.Type = VariantType.ExpandedNodeId;
@@ -309,28 +310,28 @@ namespace Workstation.ServiceModel.Ua
             this.ArrayDimensions = null;
         }
 
-        public Variant(QualifiedName value)
+        public Variant(QualifiedName? value)
         {
             this.Value = value;
             this.Type = VariantType.QualifiedName;
             this.ArrayDimensions = null;
         }
 
-        public Variant(LocalizedText value)
+        public Variant(LocalizedText? value)
         {
             this.Value = value;
             this.Type = VariantType.LocalizedText;
             this.ArrayDimensions = null;
         }
 
-        public Variant(ExtensionObject value)
+        public Variant(ExtensionObject? value)
         {
             this.Value = value;
             this.Type = VariantType.ExtensionObject;
             this.ArrayDimensions = null;
         }
 
-        public Variant(IEncodable value)
+        public Variant(IEncodable? value)
         {
             this.Value = new ExtensionObject(value);
             this.Type = VariantType.ExtensionObject;
@@ -344,8 +345,9 @@ namespace Workstation.ServiceModel.Ua
             this.ArrayDimensions = null;
         }
 
-        public Variant(bool[] value)
+        public Variant(bool[]? value)
         {
+            // REVIEW: Should we throw on null?
             this.Value = value;
             this.Type = VariantType.Boolean;
             this.ArrayDimensions = new int[value.Rank];
@@ -612,7 +614,7 @@ namespace Workstation.ServiceModel.Ua
         {
             this.Value = value;
             VariantType varType;
-            Type elemType = value.GetType().GetElementType();
+            Type? elemType = value.GetType().GetElementType();
             if (elemType == null || !elemTypeMap.TryGetValue(elemType, out varType))
             {
                 throw new ArgumentOutOfRangeException(nameof(value), elemType, "Array element type is unsupported.");
@@ -626,11 +628,11 @@ namespace Workstation.ServiceModel.Ua
             }
         }
 
-        public object Value { get; }
+        public object? Value { get; }
 
         public VariantType Type { get; }
 
-        public int[] ArrayDimensions { get; }
+        public int[]? ArrayDimensions { get; }
 
         public static implicit operator Variant(bool value)
         {
@@ -849,217 +851,217 @@ namespace Workstation.ServiceModel.Ua
 
         public static explicit operator bool(Variant value)
         {
-            return (bool)value.Value;
+            return (bool)value.Value!;
         }
 
         public static explicit operator sbyte(Variant value)
         {
-            return (sbyte)value.Value;
+            return (sbyte)value.Value!;
         }
 
         public static explicit operator byte(Variant value)
         {
-            return (byte)value.Value;
+            return (byte)value.Value!;
         }
 
         public static explicit operator short(Variant value)
         {
-            return (short)value.Value;
+            return (short)value.Value!;
         }
 
         public static explicit operator ushort(Variant value)
         {
-            return (ushort)value.Value;
+            return (ushort)value.Value!;
         }
 
         public static explicit operator int(Variant value)
         {
-            return (int)value.Value;
+            return (int)value.Value!;
         }
 
         public static explicit operator uint(Variant value)
         {
-            return (uint)value.Value;
+            return (uint)value.Value!;
         }
 
         public static explicit operator long(Variant value)
         {
-            return (long)value.Value;
+            return (long)value.Value!;
         }
 
         public static explicit operator ulong(Variant value)
         {
-            return (ulong)value.Value;
+            return (ulong)value.Value!;
         }
 
         public static explicit operator float(Variant value)
         {
-            return (float)value.Value;
+            return (float)value.Value!;
         }
 
         public static explicit operator double(Variant value)
         {
-            return (double)value.Value;
+            return (double)value.Value!;
         }
 
-        public static explicit operator string(Variant value)
+        public static explicit operator string?(Variant value)
         {
-            return (string)value.Value;
+            return (string?)value.Value;
         }
 
         public static explicit operator DateTime(Variant value)
         {
-            return (DateTime)value.Value;
+            return (DateTime)value.Value!;
         }
 
         public static explicit operator Guid(Variant value)
         {
-            return (Guid)value.Value;
+            return (Guid)value.Value!;
         }
 
-        public static explicit operator byte[] (Variant value)
+        public static explicit operator byte[]? (Variant value)
         {
-            return (byte[])value.Value;
+            return (byte[]?)value.Value;
         }
 
-        public static explicit operator XElement(Variant value)
+        public static explicit operator XElement?(Variant value)
         {
-            return (XElement)value.Value;
+            return (XElement?)value.Value;
         }
 
-        public static explicit operator NodeId(Variant value)
+        public static explicit operator NodeId?(Variant value)
         {
-            return (NodeId)value.Value;
+            return (NodeId?)value.Value;
         }
 
-        public static explicit operator ExpandedNodeId(Variant value)
+        public static explicit operator ExpandedNodeId?(Variant value)
         {
-            return (ExpandedNodeId)value.Value;
+            return (ExpandedNodeId?)value.Value;
         }
 
         public static explicit operator StatusCode(Variant value)
         {
-            return (StatusCode)value.Value;
+            return (StatusCode)value.Value!;
         }
 
         public static explicit operator QualifiedName(Variant value)
         {
-            return (QualifiedName)value.Value;
+            return (QualifiedName)value.Value!;
         }
 
-        public static explicit operator LocalizedText(Variant value)
+        public static explicit operator LocalizedText?(Variant value)
         {
-            return (LocalizedText)value.Value;
+            return (LocalizedText?)value.Value;
         }
 
-        public static explicit operator ExtensionObject(Variant value)
+        public static explicit operator ExtensionObject?(Variant value)
         {
-            return (ExtensionObject)value.Value;
+            return (ExtensionObject?)value.Value;
         }
 
-        public static explicit operator bool[] (Variant value)
+        public static explicit operator bool[]? (Variant value)
         {
-            return (bool[])value.Value;
+            return (bool[]?)value.Value;
         }
 
-        public static explicit operator sbyte[] (Variant value)
+        public static explicit operator sbyte[]? (Variant value)
         {
-            return (sbyte[])value.Value;
+            return (sbyte[]?)value.Value;
         }
 
-        public static explicit operator short[] (Variant value)
+        public static explicit operator short[]? (Variant value)
         {
-            return (short[])value.Value;
+            return (short[]?)value.Value;
         }
 
-        public static explicit operator ushort[] (Variant value)
+        public static explicit operator ushort[]? (Variant value)
         {
-            return (ushort[])value.Value;
+            return (ushort[]?)value.Value;
         }
 
-        public static explicit operator int[] (Variant value)
+        public static explicit operator int[]? (Variant value)
         {
-            return (int[])value.Value;
+            return (int[]?)value.Value;
         }
 
-        public static explicit operator uint[] (Variant value)
+        public static explicit operator uint[]? (Variant value)
         {
-            return (uint[])value.Value;
+            return (uint[]?)value.Value;
         }
 
-        public static explicit operator long[] (Variant value)
+        public static explicit operator long[]? (Variant value)
         {
-            return (long[])value.Value;
+            return (long[]?)value.Value;
         }
 
-        public static explicit operator ulong[] (Variant value)
+        public static explicit operator ulong[]? (Variant value)
         {
-            return (ulong[])value.Value;
+            return (ulong[]?)value.Value;
         }
 
-        public static explicit operator float[] (Variant value)
+        public static explicit operator float[]? (Variant value)
         {
-            return (float[])value.Value;
+            return (float[]?)value.Value;
         }
 
-        public static explicit operator double[] (Variant value)
+        public static explicit operator double[]? (Variant value)
         {
-            return (double[])value.Value;
+            return (double[]?)value.Value;
         }
 
-        public static explicit operator string[] (Variant value)
+        public static explicit operator string[]? (Variant value)
         {
-            return (string[])value.Value;
+            return (string[]?)value.Value;
         }
 
-        public static explicit operator DateTime[] (Variant value)
+        public static explicit operator DateTime[]? (Variant value)
         {
-            return (DateTime[])value.Value;
+            return (DateTime[]?)value.Value;
         }
 
-        public static explicit operator Guid[] (Variant value)
+        public static explicit operator Guid[]? (Variant value)
         {
-            return (Guid[])value.Value;
+            return (Guid[]?)value.Value;
         }
 
-        public static explicit operator byte[][] (Variant value)
+        public static explicit operator byte[][]? (Variant value)
         {
-            return (byte[][])value.Value;
+            return (byte[][]?)value.Value;
         }
 
-        public static explicit operator XElement[] (Variant value)
+        public static explicit operator XElement[]? (Variant value)
         {
-            return (XElement[])value.Value;
+            return (XElement[]?)value.Value;
         }
 
-        public static explicit operator NodeId[] (Variant value)
+        public static explicit operator NodeId[]? (Variant value)
         {
-            return (NodeId[])value.Value;
+            return (NodeId[]?)value.Value;
         }
 
-        public static explicit operator ExpandedNodeId[] (Variant value)
+        public static explicit operator ExpandedNodeId[]? (Variant value)
         {
-            return (ExpandedNodeId[])value.Value;
+            return (ExpandedNodeId[]?)value.Value;
         }
 
-        public static explicit operator StatusCode[] (Variant value)
+        public static explicit operator StatusCode[]? (Variant value)
         {
-            return (StatusCode[])value.Value;
+            return (StatusCode[]?)value.Value;
         }
 
-        public static explicit operator QualifiedName[] (Variant value)
+        public static explicit operator QualifiedName[]? (Variant value)
         {
-            return (QualifiedName[])value.Value;
+            return (QualifiedName[]?)value.Value;
         }
 
-        public static explicit operator LocalizedText[] (Variant value)
+        public static explicit operator LocalizedText[]? (Variant value)
         {
-            return (LocalizedText[])value.Value;
+            return (LocalizedText[]?)value.Value;
         }
 
-        public static explicit operator ExtensionObject[] (Variant value)
+        public static explicit operator ExtensionObject[]? (Variant value)
         {
-            return (ExtensionObject[])value.Value;
+            return (ExtensionObject[]?)value.Value;
         }
 
         public static bool IsNull(Variant a)


### PR DESCRIPTION
Here the NRT raises some interesting questions: is it allowed to pass null values to the different constructor variants like `Variant(string? value)` or should we restrict it to `Variant(string value)`. The first version does not throw an can be serialized. The binary encoder will serialize it as an untyped null value. That's what the reference implementation does as well, so this seems to be correct. But if we should agree on this, shouldn't that also be true for `Variant(int[] value)`? Because here the constructor would throw on `null` values.