### PR TITLE
More NRT annotiations

### DIFF
--- a/UaClient/Collections/ErrorsContainer.cs
+++ b/UaClient/Collections/ErrorsContainer.cs
@@ -5,6 +5,8 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 
+#nullable enable
+
 namespace Workstation.Collections
 {
     /// <summary>
@@ -53,7 +55,7 @@ namespace Workstation.Collections
         public IEnumerable<T> GetErrors(string propertyName)
         {
             var localPropertyName = propertyName ?? string.Empty;
-            List<T> currentValidationResults = null;
+            List<T>? currentValidationResults = null;
             if (this.validationResults.TryGetValue(localPropertyName, out currentValidationResults))
             {
                 return currentValidationResults;
@@ -94,7 +96,7 @@ namespace Workstation.Collections
             {
                 if (hasNewValidationResults)
                 {
-                    this.validationResults[localPropertyName] = new List<T>(newValidationResults);
+                    this.validationResults[localPropertyName] = new List<T>(newValidationResults!);
                     this.raiseErrorsChanged(localPropertyName);
                 }
                 else

--- a/UaClient/Collections/ObservableQueue.cs
+++ b/UaClient/Collections/ObservableQueue.cs
@@ -5,6 +5,8 @@ using System.Collections.Generic;
 using System.Collections.Specialized;
 using System.ComponentModel;
 
+#nullable enable
+
 namespace Workstation.Collections
 {
     /// <summary>
@@ -38,12 +40,12 @@ namespace Workstation.Collections
         /// <summary>
         /// Occurs when an item is added, removed, changed, moved, or the entire list is refreshed.
         /// </summary>
-        public event NotifyCollectionChangedEventHandler CollectionChanged;
+        public event NotifyCollectionChangedEventHandler? CollectionChanged;
 
         /// <summary>
         /// Occurs when a property value changes.
         /// </summary>
-        public event PropertyChangedEventHandler PropertyChanged;
+        public event PropertyChangedEventHandler? PropertyChanged;
 
         /// <summary>
         /// Removes all objects from the queue.

--- a/UaClient/ServiceModel/Ua/Channels/CommunicationObject.cs
+++ b/UaClient/ServiceModel/Ua/Channels/CommunicationObject.cs
@@ -7,6 +7,8 @@ using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
 
+#nullable enable
+
 namespace Workstation.ServiceModel.Ua.Channels
 {
     /// <summary>
@@ -14,7 +16,7 @@ namespace Workstation.ServiceModel.Ua.Channels
     /// </summary>
     public abstract class CommunicationObject : ICommunicationObject
     {
-        private readonly ILogger logger;
+        private readonly ILogger? logger;
         private bool aborted;
         private bool onClosingCalled;
         private bool onClosedCalled;
@@ -30,22 +32,22 @@ namespace Workstation.ServiceModel.Ua.Channels
         /// Initializes a new instance of the <see cref="CommunicationObject"/> class.
         /// </summary>
         /// <param name="loggerFactory">The logger.</param>
-        public CommunicationObject(ILoggerFactory loggerFactory = null)
+        public CommunicationObject(ILoggerFactory? loggerFactory = null)
         {
             this.logger = loggerFactory?.CreateLogger(this.GetType());
             this.semaphore = new SemaphoreSlim(1);
             this.exceptions = new Lazy<ConcurrentQueue<Exception>>();
         }
 
-        public event EventHandler Closed;
+        public event EventHandler? Closed;
 
-        public event EventHandler Closing;
+        public event EventHandler? Closing;
 
-        public event EventHandler Faulted;
+        public event EventHandler? Faulted;
 
-        public event EventHandler Opened;
+        public event EventHandler? Opened;
 
-        public event EventHandler Opening;
+        public event EventHandler? Opening;
 
         /// <summary>
         /// Gets or sets gets a value that indicates the current state of the communication object.
@@ -300,7 +302,7 @@ namespace Workstation.ServiceModel.Ua.Channels
             }
 
             this.logger?.LogTrace($"Channel closed.");
-            EventHandler closed = this.Closed;
+            EventHandler? closed = this.Closed;
             if (closed != null)
             {
                 closed(this, EventArgs.Empty);
@@ -331,7 +333,7 @@ namespace Workstation.ServiceModel.Ua.Channels
             }
 
             this.logger?.LogTrace($"Channel closing.");
-            EventHandler closing = this.Closing;
+            EventHandler? closing = this.Closing;
             if (closing != null)
             {
                 closing(this, EventArgs.Empty);
@@ -361,7 +363,7 @@ namespace Workstation.ServiceModel.Ua.Channels
             }
 
             this.logger?.LogTrace($"Channel faulted.");
-            EventHandler faulted = this.Faulted;
+            EventHandler? faulted = this.Faulted;
             if (faulted != null)
             {
                 faulted(this, EventArgs.Empty);
@@ -399,7 +401,7 @@ namespace Workstation.ServiceModel.Ua.Channels
             }
 
             this.logger?.LogTrace($"Channel opened.");
-            EventHandler opened = this.Opened;
+            EventHandler? opened = this.Opened;
             if (opened != null)
             {
                 opened(this, EventArgs.Empty);
@@ -424,7 +426,7 @@ namespace Workstation.ServiceModel.Ua.Channels
             }
 
             this.logger?.LogTrace($"Channel opening.");
-            EventHandler opening = this.Opening;
+            EventHandler? opening = this.Opening;
             if (opening != null)
             {
                 opening(this, EventArgs.Empty);
@@ -436,10 +438,9 @@ namespace Workstation.ServiceModel.Ua.Channels
             this.exceptions.Value.Enqueue(exception);
         }
 
-        protected Exception GetPendingException()
+        protected Exception? GetPendingException()
         {
-            Exception ex;
-            if (this.exceptions.Value.TryDequeue(out ex))
+            if (this.exceptions.Value.TryDequeue(out var ex))
             {
                 return ex;
             }
@@ -449,7 +450,7 @@ namespace Workstation.ServiceModel.Ua.Channels
 
         protected void ThrowPending()
         {
-            Exception exception = this.GetPendingException();
+            Exception? exception = this.GetPendingException();
             if (exception != null)
             {
                 throw exception;

--- a/UaClient/ServiceModel/Ua/Channels/ServiceOperation.cs
+++ b/UaClient/ServiceModel/Ua/Channels/ServiceOperation.cs
@@ -3,6 +3,8 @@
 
 using System.Threading.Tasks;
 
+#nullable enable
+
 namespace Workstation.ServiceModel.Ua.Channels
 {
     public class ServiceOperation : TaskCompletionSource<IServiceResponse>
@@ -19,6 +21,6 @@ namespace Workstation.ServiceModel.Ua.Channels
         /// <summary>
         /// Gets the request.
         /// </summary>
-        public IServiceRequest Request => (IServiceRequest)this.Task.AsyncState;
+        public IServiceRequest Request => (IServiceRequest)this.Task.AsyncState!;
     }
 }

--- a/UaClient/ServiceModel/Ua/DataValue.cs
+++ b/UaClient/ServiceModel/Ua/DataValue.cs
@@ -3,11 +3,13 @@
 
 using System;
 
+#nullable enable
+
 namespace Workstation.ServiceModel.Ua
 {
     public sealed class DataValue
     {
-        public DataValue(object value, StatusCode statusCode = default(StatusCode), DateTime sourceTimestamp = default(DateTime), ushort sourcePicoseconds = 0, DateTime serverTimestamp = default(DateTime), ushort serverPicoseconds = 0)
+        public DataValue(object? value, StatusCode statusCode = default(StatusCode), DateTime sourceTimestamp = default(DateTime), ushort sourcePicoseconds = 0, DateTime serverTimestamp = default(DateTime), ushort serverPicoseconds = 0)
         {
             this.Variant = new Variant(value);
             this.StatusCode = statusCode;
@@ -27,7 +29,7 @@ namespace Workstation.ServiceModel.Ua
             this.ServerPicoseconds = serverPicoseconds;
         }
 
-        public object Value
+        public object? Value
         {
             get { return this.Variant.Value; }
         }

--- a/UaClient/ServiceModel/Ua/DataValueExtensions.cs
+++ b/UaClient/ServiceModel/Ua/DataValueExtensions.cs
@@ -2,7 +2,10 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
+using System.Diagnostics.CodeAnalysis;
 using System.Linq;
+
+#nullable enable
 
 namespace Workstation.ServiceModel.Ua
 {
@@ -13,7 +16,7 @@ namespace Workstation.ServiceModel.Ua
         /// </summary>
         /// <param name="dataValue">The DataValue.</param>
         /// <returns>The value.</returns>
-        public static object GetValue(this DataValue dataValue)
+        public static object? GetValue(this DataValue dataValue)
         {
             var value = dataValue.Value;
             switch (value)
@@ -38,6 +41,7 @@ namespace Workstation.ServiceModel.Ua
         /// <typeparam name="T">The expected type.</typeparam>
         /// <param name="dataValue">The DataValue.</param>
         /// <returns>The value, if an instance of the specified Type, otherwise the Type's default value.</returns>
+        [return: MaybeNull]
         public static T GetValueOrDefault<T>(this DataValue dataValue)
         {
             var value = dataValue.GetValue();
@@ -49,7 +53,11 @@ namespace Workstation.ServiceModel.Ua
                 }
             }
 
-            return default(T);
+            // While [MaybeNull] attribute signals to the caller
+            // that the return value can be null. It is ignored
+            // by the compiler inside of the method, hence we
+            // have to use the bang operator.
+            return default!;
         }
 
         /// <summary>
@@ -59,6 +67,7 @@ namespace Workstation.ServiceModel.Ua
         /// <param name="dataValue">A DataValue</param>
         /// <param name="defaultValue">A default value.</param>
         /// <returns>The value, if an instance of the specified Type, otherwise the specified default value.</returns>
+        [return: NotNullIfNotNull("defaultValue")]
         public static T GetValueOrDefault<T>(this DataValue dataValue, T defaultValue)
         {
             var value = dataValue.GetValue();

--- a/UaClient/ServiceModel/Ua/DiagnosticFlags.cs
+++ b/UaClient/ServiceModel/Ua/DiagnosticFlags.cs
@@ -3,6 +3,8 @@
 
 using System;
 
+#nullable enable
+
 namespace Workstation.ServiceModel.Ua
 {
     [Flags]

--- a/UaClient/ServiceModel/Ua/DiagnosticInfo.cs
+++ b/UaClient/ServiceModel/Ua/DiagnosticInfo.cs
@@ -1,11 +1,13 @@
 ﻿// Copyright (c) Converter Systems LLC. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+#nullable enable
+
 namespace Workstation.ServiceModel.Ua
 {
     public sealed class DiagnosticInfo
     {
-        public DiagnosticInfo(int namespaceUri = -1, int symbolicId = -1, int locale = -1, int localizedText = -1, string additionalInfo = null, StatusCode innerStatusCode = default(StatusCode), DiagnosticInfo innerDiagnosticInfo = null)
+        public DiagnosticInfo(int namespaceUri = -1, int symbolicId = -1, int locale = -1, int localizedText = -1, string? additionalInfo = null, StatusCode innerStatusCode = default(StatusCode), DiagnosticInfo? innerDiagnosticInfo = null)
         {
             this.NamespaceUri = namespaceUri;
             this.SymbolicId = symbolicId;
@@ -24,10 +26,10 @@ namespace Workstation.ServiceModel.Ua
 
         public int LocalizedText { get; }
 
-        public string AdditionalInfo { get; }
+        public string? AdditionalInfo { get; }
 
         public StatusCode InnerStatusCode { get; }
 
-        public DiagnosticInfo InnerDiagnosticInfo { get; }
+        public DiagnosticInfo? InnerDiagnosticInfo { get; }
     }
 }

--- a/UaClient/ServiceModel/Ua/DirectoryStore.cs
+++ b/UaClient/ServiceModel/Ua/DirectoryStore.cs
@@ -19,6 +19,8 @@ using Org.BouncyCastle.X509;
 using Org.BouncyCastle.X509.Extension;
 using Org.BouncyCastle.X509.Store;
 
+#nullable enable
+
 namespace Workstation.ServiceModel.Ua
 {
     /// <summary>
@@ -59,7 +61,7 @@ namespace Workstation.ServiceModel.Ua
         public bool CreateLocalCertificateIfNotExist { get; }
 
         /// <inheritdoc/>
-        public async Task<(X509Certificate Certificate, RsaKeyParameters Key)> GetLocalCertificateAsync(ApplicationDescription applicationDescription, ILogger logger = null)
+        public async Task<(X509Certificate? Certificate, RsaKeyParameters? Key)> GetLocalCertificateAsync(ApplicationDescription applicationDescription, ILogger? logger = null)
         {
             if (applicationDescription == null)
             {
@@ -72,9 +74,9 @@ namespace Workstation.ServiceModel.Ua
                 throw new ArgumentOutOfRangeException(nameof(applicationDescription), "Expecting ApplicationUri in the form of 'http://{hostname}/{appname}' -or- 'urn:{hostname}:{appname}'.");
             }
 
-            string subjectName = null;
-            string hostName = null;
-            string appName = null;
+            string? subjectName = null;
+            string? hostName = null;
+            string? appName = null;
 
             UriBuilder appUri = new UriBuilder(applicationUri);
             if (appUri.Scheme == "http" && !string.IsNullOrEmpty(appUri.Host))
@@ -265,7 +267,7 @@ namespace Workstation.ServiceModel.Ua
         }
 
         /// <inheritdoc/>
-        public Task<bool> ValidateRemoteCertificateAsync(X509Certificate target, ILogger logger = null)
+        public Task<bool> ValidateRemoteCertificateAsync(X509Certificate target, ILogger? logger = null)
         {
             if (this.AcceptAllRemoteCertificates)
             {
@@ -359,7 +361,7 @@ namespace Workstation.ServiceModel.Ua
 
             // Create the trust anchors (set of root CA certificates)
             var trustAnchors = new Org.BouncyCastle.Utilities.Collections.HashSet();
-            foreach (X509Certificate trustedRootCert in trustedRootCerts)
+            foreach (X509Certificate? trustedRootCert in trustedRootCerts)
             {
                 trustAnchors.Add(new TrustAnchor(trustedRootCert, null));
             }

--- a/UaClient/ServiceModel/Ua/EventHelper.cs
+++ b/UaClient/ServiceModel/Ua/EventHelper.cs
@@ -6,6 +6,8 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
 
+#nullable enable
+
 namespace Workstation.ServiceModel.Ua
 {
     public static class EventHelper
@@ -17,7 +19,7 @@ namespace Workstation.ServiceModel.Ua
             where T : BaseEvent, new()
         {
             var e = Activator.CreateInstance<T>();
-            if (DeserializerCache.TryGetValue(typeof(T), out PropertyInfo[] infos))
+            if (DeserializerCache.TryGetValue(typeof(T), out var infos))
             {
                 for (int i = 0; i < eventFields.Length; i++)
                 {
@@ -30,8 +32,8 @@ namespace Workstation.ServiceModel.Ua
 
         public static BaseEvent Deserialize(Type type, Variant[] eventFields)
         {
-            var e = (BaseEvent)Activator.CreateInstance(type);
-            if (DeserializerCache.TryGetValue(type, out PropertyInfo[] infos))
+            var e = (BaseEvent)Activator.CreateInstance(type)!;
+            if (DeserializerCache.TryGetValue(type, out var infos))
             {
                 for (int i = 0; i < eventFields.Length; i++)
                 {
@@ -46,7 +48,7 @@ namespace Workstation.ServiceModel.Ua
             where T : BaseEvent, new()
         {
             var type = typeof(T);
-            if (SelectClauseCache.TryGetValue(type, out SimpleAttributeOperand[] clauses))
+            if (SelectClauseCache.TryGetValue(type, out var clauses))
             {
                 return clauses;
             }
@@ -57,7 +59,7 @@ namespace Workstation.ServiceModel.Ua
 
         public static SimpleAttributeOperand[] GetSelectClauses(Type type)
         {
-            if (SelectClauseCache.TryGetValue(type, out SimpleAttributeOperand[] clauses))
+            if (SelectClauseCache.TryGetValue(type, out var clauses))
             {
                 return clauses;
             }

--- a/UaClient/ServiceModel/Ua/ExpandedNodeId.cs
+++ b/UaClient/ServiceModel/Ua/ExpandedNodeId.cs
@@ -81,7 +81,7 @@ namespace Workstation.ServiceModel.Ua
             return (nodeId == null) || NodeId.IsNull(nodeId.NodeId);
         }
 
-        public static NodeId ToNodeId(ExpandedNodeId value, IList<string?>? namespaceUris)
+        public static NodeId ToNodeId(ExpandedNodeId value, IList<string>? namespaceUris)
         {
             if (ReferenceEquals(value, null))
             {
@@ -92,7 +92,7 @@ namespace Workstation.ServiceModel.Ua
             var nsu = value.NamespaceUri;
             if (namespaceUris != null && !string.IsNullOrEmpty(nsu))
             {
-                int i = namespaceUris.IndexOf(nsu);
+                int i = namespaceUris.IndexOf(nsu!);
                 if (i != -1)
                 {
                     ns = (ushort)i;

--- a/UaClient/ServiceModel/Ua/QualifiedName.cs
+++ b/UaClient/ServiceModel/Ua/QualifiedName.cs
@@ -3,6 +3,8 @@
 
 using System;
 
+#nullable enable
+
 namespace Workstation.ServiceModel.Ua
 {
     public sealed class QualifiedName
@@ -12,17 +14,17 @@ namespace Workstation.ServiceModel.Ua
         /// </summary>
         /// <param name="name">the text portion of the QualifiedName. </param>
         /// <param name="namespaceIndex">index that identifies the namespace that qualifies the name.</param>
-        public QualifiedName(string name, ushort namespaceIndex = 0)
+        public QualifiedName(string? name, ushort namespaceIndex = 0)
         {
             this.Name = name;
             this.NamespaceIndex = namespaceIndex;
         }
 
-        public string Name { get; private set; }
+        public string? Name { get; private set; }
 
         public ushort NamespaceIndex { get; private set; }
 
-        public static bool operator ==(QualifiedName a, QualifiedName b)
+        public static bool operator ==(QualifiedName? a, QualifiedName? b)
         {
             if (ReferenceEquals(a, b))
             {
@@ -37,7 +39,7 @@ namespace Workstation.ServiceModel.Ua
             return (a.Name == b.Name) && (a.NamespaceIndex == b.NamespaceIndex);
         }
 
-        public static bool operator !=(QualifiedName a, QualifiedName b)
+        public static bool operator !=(QualifiedName? a, QualifiedName? b)
         {
             return !(a == b);
         }
@@ -76,7 +78,7 @@ namespace Workstation.ServiceModel.Ua
             return value;
         }
 
-        public override bool Equals(object o)
+        public override bool Equals(object? o)
         {
             if (o is QualifiedName)
             {
@@ -86,7 +88,7 @@ namespace Workstation.ServiceModel.Ua
             return false;
         }
 
-        public bool Equals(QualifiedName that)
+        public bool Equals(QualifiedName? that)
         {
             return this == that;
         }

--- a/UaClient/ServiceModel/Ua/StatusCode.cs
+++ b/UaClient/ServiceModel/Ua/StatusCode.cs
@@ -1,6 +1,8 @@
 ﻿// Copyright (c) Converter Systems LLC. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+#nullable enable
+
 namespace Workstation.ServiceModel.Ua
 {
     public struct StatusCode
@@ -79,7 +81,7 @@ namespace Workstation.ServiceModel.Ua
             return ((a.Value & InfoTypeMask) == InfoTypeDataValue) && ((a.Value & Overflow) == Overflow);
         }
 
-        public override bool Equals(object o)
+        public override bool Equals(object? o)
         {
             if (o is StatusCode)
             {

--- a/UaClient/ServiceModel/Ua/VariantExtensions.cs
+++ b/UaClient/ServiceModel/Ua/VariantExtensions.cs
@@ -2,8 +2,11 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
+using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Reflection;
+
+#nullable enable
 
 namespace Workstation.ServiceModel.Ua
 {
@@ -14,7 +17,7 @@ namespace Workstation.ServiceModel.Ua
         /// </summary>
         /// <param name="variant">The Variant.</param>
         /// <returns>The value.</returns>
-        public static object GetValue(this Variant variant)
+        public static object? GetValue(this Variant variant)
         {
             var value = variant.Value;
             switch (value)
@@ -39,6 +42,7 @@ namespace Workstation.ServiceModel.Ua
         /// <typeparam name="T">The expected type.</typeparam>
         /// <param name="variant">The Variant.</param>
         /// <returns>The value, if an instance of the specified Type, otherwise the Type's default value.</returns>
+        [return: MaybeNull]
         public static T GetValueOrDefault<T>(this Variant variant)
         {
             var value = variant.GetValue();
@@ -50,7 +54,7 @@ namespace Workstation.ServiceModel.Ua
                 }
             }
 
-            return default(T);
+            return default(T)!;
         }
 
         /// <summary>
@@ -60,6 +64,7 @@ namespace Workstation.ServiceModel.Ua
         /// <param name="variant">A Variant</param>
         /// <param name="defaultValue">A default value.</param>
         /// <returns>The value, if an instance of the specified Type, otherwise the specified default value.</returns>
+        [return: NotNullIfNotNull("defaultValue")]
         public static T GetValueOrDefault<T>(this Variant variant, T defaultValue)
         {
             var value = variant.GetValue();


### PR DESCRIPTION
The most changes here where straight forward. In some cases I had to use the bang operator `!`. Sometimes the compiler is not smart enough (`if (!string.IsNullOrEmpty(nsu))`) or the annotation is not expressive enough ('this.Task.AsyncState') to describe that the object is not null.