### PR TITLE
Make `Variant` and `StatusCode` readonly structs

### DIFF
--- a/UaClient/ServiceModel/Ua/StatusCode.cs
+++ b/UaClient/ServiceModel/Ua/StatusCode.cs
@@ -3,7 +3,7 @@
 
 namespace Workstation.ServiceModel.Ua
 {
-    public struct StatusCode
+    public readonly struct StatusCode
     {
         private const uint SeverityMask = 0xC0000000u;
         private const uint SeverityGood = 0x00000000u;

--- a/UaClient/ServiceModel/Ua/Variant.cs
+++ b/UaClient/ServiceModel/Ua/Variant.cs
@@ -40,7 +40,7 @@ namespace Workstation.ServiceModel.Ua
         DiagnosticInfo = 25,
     }
 
-    public struct Variant
+    public readonly struct Variant
     {
         public static readonly Variant Null = default(Variant);
 


### PR DESCRIPTION
Readonly structs prevent the compilers to make defensive copys for readonly fields. Although I do not expect any measureable performance benefits for those two data types in real world programs, I think, it denotes their intentention as immutable value types. Note: this is _not_ a breaking change.