### PR TITLE
Add nullable reference type annotations for the binary encoding

### DIFF
--- a/UaClient/ServiceModel/Ua/Channels/BinaryEncoder.cs
+++ b/UaClient/ServiceModel/Ua/Channels/BinaryEncoder.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
+using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
 using System.IO;
 using System.Linq;
@@ -9,17 +10,19 @@ using System.Reflection;
 using System.Text;
 using System.Xml.Linq;
 
+#nullable enable
+
 namespace Workstation.ServiceModel.Ua.Channels
 {
     public sealed class BinaryEncoder : IEncoder, IDisposable
     {
         private const long MinFileTime = 504911232000000000L;
         private readonly Stream stream;
-        private readonly UaTcpSecureChannel channel;
+        private readonly UaTcpSecureChannel? channel;
         private readonly Encoding encoding;
         private readonly BinaryWriter writer;
 
-        public BinaryEncoder(Stream stream, UaTcpSecureChannel channel = null, bool keepStreamOpen = false)
+        public BinaryEncoder(Stream stream, UaTcpSecureChannel? channel = null, bool keepStreamOpen = false)
         {
             if (stream == null)
             {
@@ -54,62 +57,62 @@ namespace Workstation.ServiceModel.Ua.Channels
         {
         }
 
-        public void WriteBoolean(string fieldName, bool value)
+        public void WriteBoolean(string? fieldName, bool value)
         {
             this.writer.Write(value);
         }
 
-        public void WriteSByte(string fieldName, sbyte value)
+        public void WriteSByte(string? fieldName, sbyte value)
         {
             this.writer.Write(value);
         }
 
-        public void WriteByte(string fieldName, byte value)
+        public void WriteByte(string? fieldName, byte value)
         {
             this.writer.Write(value);
         }
 
-        public void WriteInt16(string fieldName, short value)
+        public void WriteInt16(string? fieldName, short value)
         {
             this.writer.Write(value);
         }
 
-        public void WriteUInt16(string fieldName, ushort value)
+        public void WriteUInt16(string? fieldName, ushort value)
         {
             this.writer.Write(value);
         }
 
-        public void WriteInt32(string fieldName, int value)
+        public void WriteInt32(string? fieldName, int value)
         {
             this.writer.Write(value);
         }
 
-        public void WriteUInt32(string fieldName, uint value)
+        public void WriteUInt32(string? fieldName, uint value)
         {
             this.writer.Write(value);
         }
 
-        public void WriteInt64(string fieldName, long value)
+        public void WriteInt64(string? fieldName, long value)
         {
             this.writer.Write(value);
         }
 
-        public void WriteUInt64(string fieldName, ulong value)
+        public void WriteUInt64(string? fieldName, ulong value)
         {
             this.writer.Write(value);
         }
 
-        public void WriteFloat(string fieldName, float value)
+        public void WriteFloat(string? fieldName, float value)
         {
             this.writer.Write(value);
         }
 
-        public void WriteDouble(string fieldName, double value)
+        public void WriteDouble(string? fieldName, double value)
         {
             this.writer.Write(value);
         }
 
-        public void WriteString(string fieldName, string value)
+        public void WriteString(string? fieldName, string? value)
         {
             if (value == null)
             {
@@ -120,7 +123,7 @@ namespace Workstation.ServiceModel.Ua.Channels
             this.WriteByteString(null, this.encoding.GetBytes(value));
         }
 
-        public void WriteDateTime(string fieldName, DateTime value)
+        public void WriteDateTime(string? fieldName, DateTime value)
         {
             if (value.Kind == DateTimeKind.Local)
             {
@@ -136,12 +139,12 @@ namespace Workstation.ServiceModel.Ua.Channels
             this.writer.Write(value.ToFileTimeUtc());
         }
 
-        public void WriteGuid(string fieldName, Guid value)
+        public void WriteGuid(string? fieldName, Guid value)
         {
             this.writer.Write(value.ToByteArray());
         }
 
-        public void WriteByteString(string fieldName, byte[] value)
+        public void WriteByteString(string? fieldName, byte[]? value)
         {
             if (value == null)
             {
@@ -153,7 +156,7 @@ namespace Workstation.ServiceModel.Ua.Channels
             this.writer.Write(value);
         }
 
-        public void WriteXElement(string fieldName, XElement value)
+        public void WriteXElement(string? fieldName, XElement? value)
         {
             if (value == null)
             {
@@ -164,7 +167,7 @@ namespace Workstation.ServiceModel.Ua.Channels
             this.WriteByteString(null, this.encoding.GetBytes(value.ToString()));
         }
 
-        public void WriteNodeId(string fieldName, NodeId value)
+        public void WriteNodeId(string? fieldName, NodeId? value)
         {
             if (value == null)
             {
@@ -221,7 +224,7 @@ namespace Workstation.ServiceModel.Ua.Channels
             }
         }
 
-        public void WriteExpandedNodeId(string fieldName, ExpandedNodeId value)
+        public void WriteExpandedNodeId(string? fieldName, ExpandedNodeId? value)
         {
             if (value == null)
             {
@@ -306,12 +309,12 @@ namespace Workstation.ServiceModel.Ua.Channels
             }
         }
 
-        public void WriteStatusCode(string fieldName, StatusCode value)
+        public void WriteStatusCode(string? fieldName, StatusCode value)
         {
             this.WriteUInt32(null, value.Value);
         }
 
-        public void WriteDiagnosticInfo(string fieldName, DiagnosticInfo value)
+        public void WriteDiagnosticInfo(string? fieldName, DiagnosticInfo? value)
         {
             if (value == null)
             {
@@ -392,7 +395,7 @@ namespace Workstation.ServiceModel.Ua.Channels
             }
         }
 
-        public void WriteQualifiedName(string fieldName, QualifiedName value)
+        public void WriteQualifiedName(string? fieldName, QualifiedName? value)
         {
             if (value == null)
             {
@@ -405,7 +408,7 @@ namespace Workstation.ServiceModel.Ua.Channels
             this.WriteString(null, value.Name);
         }
 
-        public void WriteLocalizedText(string fieldName, LocalizedText value)
+        public void WriteLocalizedText(string? fieldName, LocalizedText? value)
         {
             if (value == null)
             {
@@ -436,17 +439,17 @@ namespace Workstation.ServiceModel.Ua.Channels
             }
         }
 
-        public void WriteVariant(string fieldName, Variant value)
+        public void WriteVariant(string? fieldName, Variant value)
         {
-            if (Variant.IsNull(value))
+            var obj = value.Value;
+            if (obj is null || Variant.IsNull(value))
             {
                 this.WriteByte(null, 0);
                 return;
             }
 
-            object obj = value.Value;
             byte b = (byte)value.Type;
-            int[] dims = value.ArrayDimensions;
+            int[]? dims = value.ArrayDimensions;
             if (dims == null)
             {
                 this.WriteByte(null, b);
@@ -652,7 +655,7 @@ namespace Workstation.ServiceModel.Ua.Channels
                 return;
             }
 
-            var a1 = obj as Array;
+            var a1 = (Array)obj;
             b |= 64;
             this.WriteByte(null, b);
             switch (value.Type)
@@ -756,7 +759,7 @@ namespace Workstation.ServiceModel.Ua.Channels
             this.WriteInt32Array(null, dims);
         }
 
-        public void WriteDataValue(string fieldName, DataValue value)
+        public void WriteDataValue(string? fieldName, DataValue? value)
         {
             if (value == null)
             {
@@ -827,7 +830,7 @@ namespace Workstation.ServiceModel.Ua.Channels
             }
         }
 
-        public void WriteExtensionObject(string fieldName, ExtensionObject value)
+        public void WriteExtensionObject(string? fieldName, ExtensionObject? value)
         {
             if (value == null || value.BodyType == BodyType.None)
             {
@@ -836,30 +839,34 @@ namespace Workstation.ServiceModel.Ua.Channels
                 return;
             }
 
+            // If the body type is not none, than the type id
+            // is guaranteed to be not null
+            var typeId = value.TypeId!;
+
             if (value.BodyType == BodyType.ByteString)
             {
-                this.WriteNodeId(null, ExpandedNodeId.ToNodeId(value.TypeId, this.channel?.NamespaceUris));
+                this.WriteNodeId(null, ExpandedNodeId.ToNodeId(typeId, this.channel?.NamespaceUris));
                 this.WriteByte(null, 0x01);
-                this.WriteByteString(null, (byte[])value.Body);
+                this.WriteByteString(null, (byte[]?)value.Body);
                 return;
             }
 
             if (value.BodyType == BodyType.XmlElement)
             {
-                this.WriteNodeId(null, ExpandedNodeId.ToNodeId(value.TypeId, this.channel?.NamespaceUris));
+                this.WriteNodeId(null, ExpandedNodeId.ToNodeId(typeId, this.channel?.NamespaceUris));
                 this.WriteByte(null, 0x02);
-                this.WriteXElement(null, (XElement)value.Body);
+                this.WriteXElement(null, (XElement?)value.Body);
                 return;
             }
 
             if (value.BodyType == BodyType.Encodable)
             {
-                this.WriteNodeId(null, ExpandedNodeId.ToNodeId(value.TypeId, this.channel?.NamespaceUris));
+                this.WriteNodeId(null, ExpandedNodeId.ToNodeId(typeId, this.channel?.NamespaceUris));
                 this.WriteByte(null, 0x01); // BodyType Encodable is encoded as ByteString.
                 var pos0 = this.writer.BaseStream.Position;
                 this.WriteInt32(null, -1);
                 var pos1 = this.writer.BaseStream.Position;
-                ((IEncodable)value.Body).Encode(this);
+                ((IEncodable)value.Body!).Encode(this);
                 var pos2 = this.writer.BaseStream.Position;
                 this.writer.Seek((int)pos0, SeekOrigin.Begin);
                 this.WriteInt32(null, (int)(pos2 - pos1));
@@ -868,8 +875,8 @@ namespace Workstation.ServiceModel.Ua.Channels
             }
         }
 
-        public void WriteExtensionObject<T>(string fieldName, T value)
-            where T : class, IEncodable
+        public void WriteExtensionObject<T>(string? fieldName, T value)
+            where T : class?, IEncodable
         {
             if (value == null)
             {
@@ -879,7 +886,7 @@ namespace Workstation.ServiceModel.Ua.Channels
             }
 
             var type = value.GetType();
-            if (!this.channel.TryGetBinaryEncodingIdFromType(type, out NodeId binaryEncodingId))
+            if (this.channel is null || !this.channel.TryGetBinaryEncodingIdFromType(type, out NodeId binaryEncodingId))
             {
                 throw new ServiceResultException(StatusCodes.BadEncodingError);
             }
@@ -897,7 +904,7 @@ namespace Workstation.ServiceModel.Ua.Channels
             return;
         }
 
-        public void WriteEncodable<T>(string fieldName, T value)
+        public void WriteEncodable<T>(string? fieldName, T value)
             where T : class, IEncodable
         {
             if (value == null)
@@ -908,13 +915,13 @@ namespace Workstation.ServiceModel.Ua.Channels
             value.Encode(this);
         }
 
-        public void WriteEnumeration<T>(string fieldName, T value)
+        public void WriteEnumeration<T>(string? fieldName, T value)
             where T : struct, IConvertible
         {
             this.WriteInt32(null, Convert.ToInt32(value, CultureInfo.InvariantCulture));
         }
 
-        public void WriteBooleanArray(string fieldName, bool[] values)
+        public void WriteBooleanArray(string? fieldName, bool[]? values)
         {
             if (this.TryWriteArrayLength(values))
             {
@@ -925,7 +932,7 @@ namespace Workstation.ServiceModel.Ua.Channels
             }
         }
 
-        public void WriteSByteArray(string fieldName, sbyte[] values)
+        public void WriteSByteArray(string? fieldName, sbyte[]? values)
         {
             if (this.TryWriteArrayLength(values))
             {
@@ -936,7 +943,7 @@ namespace Workstation.ServiceModel.Ua.Channels
             }
         }
 
-        public void WriteByteArray(string fieldName, byte[] values)
+        public void WriteByteArray(string? fieldName, byte[]? values)
         {
             if (this.TryWriteArrayLength(values))
             {
@@ -947,7 +954,7 @@ namespace Workstation.ServiceModel.Ua.Channels
             }
         }
 
-        public void WriteInt16Array(string fieldName, short[] values)
+        public void WriteInt16Array(string? fieldName, short[]? values)
         {
             if (this.TryWriteArrayLength(values))
             {
@@ -958,7 +965,7 @@ namespace Workstation.ServiceModel.Ua.Channels
             }
         }
 
-        public void WriteUInt16Array(string fieldName, ushort[] values)
+        public void WriteUInt16Array(string? fieldName, ushort[]? values)
         {
             if (this.TryWriteArrayLength(values))
             {
@@ -969,7 +976,7 @@ namespace Workstation.ServiceModel.Ua.Channels
             }
         }
 
-        public void WriteInt32Array(string fieldName, int[] values)
+        public void WriteInt32Array(string? fieldName, int[]? values)
         {
             if (this.TryWriteArrayLength(values))
             {
@@ -980,7 +987,7 @@ namespace Workstation.ServiceModel.Ua.Channels
             }
         }
 
-        public void WriteUInt32Array(string fieldName, uint[] values)
+        public void WriteUInt32Array(string? fieldName, uint[]? values)
         {
             if (this.TryWriteArrayLength(values))
             {
@@ -991,7 +998,7 @@ namespace Workstation.ServiceModel.Ua.Channels
             }
         }
 
-        public void WriteInt64Array(string fieldName, long[] values)
+        public void WriteInt64Array(string? fieldName, long[]? values)
         {
             if (this.TryWriteArrayLength(values))
             {
@@ -1002,7 +1009,7 @@ namespace Workstation.ServiceModel.Ua.Channels
             }
         }
 
-        public void WriteUInt64Array(string fieldName, ulong[] values)
+        public void WriteUInt64Array(string? fieldName, ulong[]? values)
         {
             if (this.TryWriteArrayLength(values))
             {
@@ -1013,7 +1020,7 @@ namespace Workstation.ServiceModel.Ua.Channels
             }
         }
 
-        public void WriteFloatArray(string fieldName, float[] values)
+        public void WriteFloatArray(string? fieldName, float[]? values)
         {
             if (this.TryWriteArrayLength(values))
             {
@@ -1024,7 +1031,7 @@ namespace Workstation.ServiceModel.Ua.Channels
             }
         }
 
-        public void WriteDoubleArray(string fieldName, double[] values)
+        public void WriteDoubleArray(string? fieldName, double[]? values)
         {
             if (this.TryWriteArrayLength(values))
             {
@@ -1035,7 +1042,7 @@ namespace Workstation.ServiceModel.Ua.Channels
             }
         }
 
-        public void WriteStringArray(string fieldName, string[] values)
+        public void WriteStringArray(string? fieldName, string[]? values)
         {
             if (this.TryWriteArrayLength(values))
             {
@@ -1046,7 +1053,7 @@ namespace Workstation.ServiceModel.Ua.Channels
             }
         }
 
-        public void WriteDateTimeArray(string fieldName, DateTime[] values)
+        public void WriteDateTimeArray(string? fieldName, DateTime[]? values)
         {
             if (this.TryWriteArrayLength(values))
             {
@@ -1057,7 +1064,7 @@ namespace Workstation.ServiceModel.Ua.Channels
             }
         }
 
-        public void WriteGuidArray(string fieldName, Guid[] values)
+        public void WriteGuidArray(string? fieldName, Guid[]? values)
         {
             if (this.TryWriteArrayLength(values))
             {
@@ -1068,7 +1075,7 @@ namespace Workstation.ServiceModel.Ua.Channels
             }
         }
 
-        public void WriteByteStringArray(string fieldName, byte[][] values)
+        public void WriteByteStringArray(string? fieldName, byte[]?[]? values)
         {
             if (this.TryWriteArrayLength(values))
             {
@@ -1079,7 +1086,7 @@ namespace Workstation.ServiceModel.Ua.Channels
             }
         }
 
-        public void WriteXElementArray(string fieldName, XElement[] values)
+        public void WriteXElementArray(string? fieldName, XElement?[]? values)
         {
             if (this.TryWriteArrayLength(values))
             {
@@ -1090,7 +1097,7 @@ namespace Workstation.ServiceModel.Ua.Channels
             }
         }
 
-        public void WriteNodeIdArray(string fieldName, NodeId[] values)
+        public void WriteNodeIdArray(string? fieldName, NodeId?[]? values)
         {
             if (this.TryWriteArrayLength(values))
             {
@@ -1101,7 +1108,7 @@ namespace Workstation.ServiceModel.Ua.Channels
             }
         }
 
-        public void WriteExpandedNodeIdArray(string fieldName, ExpandedNodeId[] values)
+        public void WriteExpandedNodeIdArray(string? fieldName, ExpandedNodeId?[]? values)
         {
             if (this.TryWriteArrayLength(values))
             {
@@ -1112,7 +1119,7 @@ namespace Workstation.ServiceModel.Ua.Channels
             }
         }
 
-        public void WriteStatusCodeArray(string fieldName, StatusCode[] values)
+        public void WriteStatusCodeArray(string? fieldName, StatusCode[]? values)
         {
             if (this.TryWriteArrayLength(values))
             {
@@ -1123,7 +1130,7 @@ namespace Workstation.ServiceModel.Ua.Channels
             }
         }
 
-        public void WriteDiagnosticInfoArray(string fieldName, DiagnosticInfo[] values)
+        public void WriteDiagnosticInfoArray(string? fieldName, DiagnosticInfo?[]? values)
         {
             if (this.TryWriteArrayLength(values))
             {
@@ -1134,7 +1141,7 @@ namespace Workstation.ServiceModel.Ua.Channels
             }
         }
 
-        public void WriteQualifiedNameArray(string fieldName, QualifiedName[] values)
+        public void WriteQualifiedNameArray(string? fieldName, QualifiedName?[]? values)
         {
             if (this.TryWriteArrayLength(values))
             {
@@ -1145,7 +1152,7 @@ namespace Workstation.ServiceModel.Ua.Channels
             }
         }
 
-        public void WriteLocalizedTextArray(string fieldName, LocalizedText[] values)
+        public void WriteLocalizedTextArray(string? fieldName, LocalizedText?[]? values)
         {
             if (this.TryWriteArrayLength(values))
             {
@@ -1156,7 +1163,7 @@ namespace Workstation.ServiceModel.Ua.Channels
             }
         }
 
-        public void WriteVariantArray(string fieldName, Variant[] values)
+        public void WriteVariantArray(string? fieldName, Variant[]? values)
         {
             if (this.TryWriteArrayLength(values))
             {
@@ -1167,7 +1174,7 @@ namespace Workstation.ServiceModel.Ua.Channels
             }
         }
 
-        public void WriteDataValueArray(string fieldName, DataValue[] values)
+        public void WriteDataValueArray(string? fieldName, DataValue?[]? values)
         {
             if (this.TryWriteArrayLength(values))
             {
@@ -1178,7 +1185,7 @@ namespace Workstation.ServiceModel.Ua.Channels
             }
         }
 
-        public void WriteExtensionObjectArray(string fieldName, ExtensionObject[] values)
+        public void WriteExtensionObjectArray(string? fieldName, ExtensionObject?[]? values)
         {
             if (this.TryWriteArrayLength(values))
             {
@@ -1189,8 +1196,8 @@ namespace Workstation.ServiceModel.Ua.Channels
             }
         }
 
-        public void WriteExtensionObjectArray<T>(string fieldName, T[] values)
-            where T : class, IEncodable
+        public void WriteExtensionObjectArray<T>(string? fieldName, T[]? values)
+            where T : class?, IEncodable
         {
             if (this.TryWriteArrayLength(values))
             {
@@ -1201,8 +1208,8 @@ namespace Workstation.ServiceModel.Ua.Channels
             }
         }
 
-        public void WriteEncodableArray<T>(string fieldName, T[] values)
-            where T : class, IEncodable
+        public void WriteEncodableArray<T>(string? fieldName, T[]? values)
+            where T : class?, IEncodable
         {
             if (this.TryWriteArrayLength(values))
             {
@@ -1213,7 +1220,7 @@ namespace Workstation.ServiceModel.Ua.Channels
             }
         }
 
-        public void WriteEnumerationArray<T>(string fieldName, T[] values)
+        public void WriteEnumerationArray<T>(string? fieldName, T[]? values)
             where T : struct, IConvertible
         {
             if (this.TryWriteArrayLength(values))
@@ -1230,7 +1237,7 @@ namespace Workstation.ServiceModel.Ua.Channels
             this.writer.Write(buffer, index, count);
         }
 
-        private bool TryWriteArrayLength<T>(T[] values)
+        private bool TryWriteArrayLength<T>([NotNullWhen(returnValue: true)] T[]? values)
         {
             if (values == null)
             {

--- a/UaClient/ServiceModel/Ua/IDecoder.cs
+++ b/UaClient/ServiceModel/Ua/IDecoder.cs
@@ -4,6 +4,8 @@
 using System;
 using System.Xml.Linq;
 
+#nullable enable
+
 namespace Workstation.ServiceModel.Ua
 {
     public interface IDecoder
@@ -12,122 +14,122 @@ namespace Workstation.ServiceModel.Ua
 
         void PopNamespace();
 
-        bool ReadBoolean(string fieldName);
+        bool ReadBoolean(string? fieldName);
 
-        sbyte ReadSByte(string fieldName);
+        sbyte ReadSByte(string? fieldName);
 
-        byte ReadByte(string fieldName);
+        byte ReadByte(string? fieldName);
 
-        short ReadInt16(string fieldName);
+        short ReadInt16(string? fieldName);
 
-        ushort ReadUInt16(string fieldName);
+        ushort ReadUInt16(string? fieldName);
 
-        int ReadInt32(string fieldName);
+        int ReadInt32(string? fieldName);
 
-        uint ReadUInt32(string fieldName);
+        uint ReadUInt32(string? fieldName);
 
-        long ReadInt64(string fieldName);
+        long ReadInt64(string? fieldName);
 
-        ulong ReadUInt64(string fieldName);
+        ulong ReadUInt64(string? fieldName);
 
-        float ReadFloat(string fieldName);
+        float ReadFloat(string? fieldName);
 
-        double ReadDouble(string fieldName);
+        double ReadDouble(string? fieldName);
 
-        string ReadString(string fieldName);
+        string? ReadString(string? fieldName);
 
-        DateTime ReadDateTime(string fieldName);
+        DateTime ReadDateTime(string? fieldName);
 
-        Guid ReadGuid(string fieldName);
+        Guid ReadGuid(string? fieldName);
 
-        byte[] ReadByteString(string fieldName);
+        byte[]? ReadByteString(string? fieldName);
 
-        XElement ReadXElement(string fieldName);
+        XElement? ReadXElement(string? fieldName);
 
-        NodeId ReadNodeId(string fieldName);
+        NodeId ReadNodeId(string? fieldName);
 
-        ExpandedNodeId ReadExpandedNodeId(string fieldName);
+        ExpandedNodeId ReadExpandedNodeId(string? fieldName);
 
-        StatusCode ReadStatusCode(string fieldName);
+        StatusCode ReadStatusCode(string? fieldName);
 
-        QualifiedName ReadQualifiedName(string fieldName);
+        QualifiedName ReadQualifiedName(string? fieldName);
 
-        LocalizedText ReadLocalizedText(string fieldName);
+        LocalizedText ReadLocalizedText(string? fieldName);
 
-        ExtensionObject ReadExtensionObject(string fieldName);
+        ExtensionObject? ReadExtensionObject(string? fieldName);
 
-        T ReadExtensionObject<T>(string fieldName)
+        T? ReadExtensionObject<T>(string? fieldName)
             where T : class, IEncodable;
 
-        DataValue ReadDataValue(string fieldName);
+        DataValue ReadDataValue(string? fieldName);
 
-        Variant ReadVariant(string fieldName);
+        Variant ReadVariant(string? fieldName);
 
-        DiagnosticInfo ReadDiagnosticInfo(string fieldName);
+        DiagnosticInfo ReadDiagnosticInfo(string? fieldName);
 
-        T ReadEncodable<T>(string fieldName)
+        T ReadEncodable<T>(string? fieldName)
             where T : class, IEncodable;
 
-        T ReadEnumeration<T>(string fieldName)
+        T ReadEnumeration<T>(string? fieldName)
             where T : struct, IConvertible;
 
-        bool[] ReadBooleanArray(string fieldName);
+        bool[]? ReadBooleanArray(string? fieldName);
 
-        sbyte[] ReadSByteArray(string fieldName);
+        sbyte[]? ReadSByteArray(string? fieldName);
 
-        byte[] ReadByteArray(string fieldName);
+        byte[]? ReadByteArray(string? fieldName);
 
-        short[] ReadInt16Array(string fieldName);
+        short[]? ReadInt16Array(string? fieldName);
 
-        ushort[] ReadUInt16Array(string fieldName);
+        ushort[]? ReadUInt16Array(string? fieldName);
 
-        int[] ReadInt32Array(string fieldName);
+        int[]? ReadInt32Array(string? fieldName);
 
-        uint[] ReadUInt32Array(string fieldName);
+        uint[]? ReadUInt32Array(string? fieldName);
 
-        long[] ReadInt64Array(string fieldName);
+        long[]? ReadInt64Array(string? fieldName);
 
-        ulong[] ReadUInt64Array(string fieldName);
+        ulong[]? ReadUInt64Array(string? fieldName);
 
-        float[] ReadFloatArray(string fieldName);
+        float[]? ReadFloatArray(string? fieldName);
 
-        double[] ReadDoubleArray(string fieldName);
+        double[]? ReadDoubleArray(string? fieldName);
 
-        string[] ReadStringArray(string fieldName);
+        string?[]? ReadStringArray(string? fieldName);
 
-        DateTime[] ReadDateTimeArray(string fieldName);
+        DateTime[]? ReadDateTimeArray(string? fieldName);
 
-        Guid[] ReadGuidArray(string fieldName);
+        Guid[]? ReadGuidArray(string? fieldName);
 
-        byte[][] ReadByteStringArray(string fieldName);
+        byte[]?[]? ReadByteStringArray(string? fieldName);
 
-        XElement[] ReadXElementArray(string fieldName);
+        XElement?[]? ReadXElementArray(string? fieldName);
 
-        NodeId[] ReadNodeIdArray(string fieldName);
+        NodeId[]? ReadNodeIdArray(string? fieldName);
 
-        ExpandedNodeId[] ReadExpandedNodeIdArray(string fieldName);
+        ExpandedNodeId[]? ReadExpandedNodeIdArray(string? fieldName);
 
-        StatusCode[] ReadStatusCodeArray(string fieldName);
+        StatusCode[]? ReadStatusCodeArray(string? fieldName);
 
-        QualifiedName[] ReadQualifiedNameArray(string fieldName);
+        QualifiedName[]? ReadQualifiedNameArray(string? fieldName);
 
-        LocalizedText[] ReadLocalizedTextArray(string fieldName);
+        LocalizedText[]? ReadLocalizedTextArray(string? fieldName);
 
-        ExtensionObject[] ReadExtensionObjectArray(string fieldName);
+        ExtensionObject?[]? ReadExtensionObjectArray(string? fieldName);
 
-        T[] ReadExtensionObjectArray<T>(string fieldName)
+        T?[]? ReadExtensionObjectArray<T>(string? fieldName)
             where T : class, IEncodable;
 
-        DataValue[] ReadDataValueArray(string fieldName);
+        DataValue[]? ReadDataValueArray(string? fieldName);
 
-        Variant[] ReadVariantArray(string fieldName);
+        Variant[]? ReadVariantArray(string? fieldName);
 
-        DiagnosticInfo[] ReadDiagnosticInfoArray(string fieldName);
+        DiagnosticInfo[]? ReadDiagnosticInfoArray(string? fieldName);
 
-        T[] ReadEncodableArray<T>(string fieldName)
+        T[]? ReadEncodableArray<T>(string? fieldName)
             where T : class, IEncodable;
 
-        T[] ReadEnumerationArray<T>(string fieldName)
+        T[]? ReadEnumerationArray<T>(string fieldName)
             where T : struct, IConvertible;
     }
 }

--- a/UaClient/ServiceModel/Ua/IEncoder.cs
+++ b/UaClient/ServiceModel/Ua/IEncoder.cs
@@ -4,6 +4,8 @@
 using System;
 using System.Xml.Linq;
 
+#nullable enable
+
 namespace Workstation.ServiceModel.Ua
 {
     public interface IEncoder
@@ -12,120 +14,120 @@ namespace Workstation.ServiceModel.Ua
 
         void PopNamespace();
 
-        void WriteBoolean(string fieldName, bool value);
+        void WriteBoolean(string? fieldName, bool value);
 
-        void WriteSByte(string fieldName, sbyte value);
+        void WriteSByte(string? fieldName, sbyte value);
 
-        void WriteByte(string fieldName, byte value);
+        void WriteByte(string? fieldName, byte value);
 
-        void WriteInt16(string fieldName, short value);
+        void WriteInt16(string? fieldName, short value);
 
-        void WriteUInt16(string fieldName, ushort value);
+        void WriteUInt16(string? fieldName, ushort value);
 
-        void WriteInt32(string fieldName, int value);
+        void WriteInt32(string? fieldName, int value);
 
-        void WriteUInt32(string fieldName, uint value);
+        void WriteUInt32(string? fieldName, uint value);
 
-        void WriteInt64(string fieldName, long value);
+        void WriteInt64(string? fieldName, long value);
 
-        void WriteUInt64(string fieldName, ulong value);
+        void WriteUInt64(string? fieldName, ulong value);
 
-        void WriteFloat(string fieldName, float value);
+        void WriteFloat(string? fieldName, float value);
 
-        void WriteDouble(string fieldName, double value);
+        void WriteDouble(string? fieldName, double value);
 
-        void WriteString(string fieldName, string value);
+        void WriteString(string? fieldName, string value);
 
-        void WriteDateTime(string fieldName, DateTime value);
+        void WriteDateTime(string? fieldName, DateTime value);
 
-        void WriteGuid(string fieldName, Guid value);
+        void WriteGuid(string? fieldName, Guid value);
 
-        void WriteByteString(string fieldName, byte[] value);
+        void WriteByteString(string? fieldName, byte[]? value);
 
-        void WriteXElement(string fieldName, XElement value);
+        void WriteXElement(string? fieldName, XElement? value);
 
-        void WriteNodeId(string fieldName, NodeId value);
+        void WriteNodeId(string? fieldName, NodeId? value);
 
-        void WriteExpandedNodeId(string fieldName, ExpandedNodeId value);
+        void WriteExpandedNodeId(string? fieldName, ExpandedNodeId? value);
 
-        void WriteStatusCode(string fieldName, StatusCode value);
+        void WriteStatusCode(string? fieldName, StatusCode value);
 
-        void WriteQualifiedName(string fieldName, QualifiedName value);
+        void WriteQualifiedName(string? fieldName, QualifiedName? value);
 
-        void WriteLocalizedText(string fieldName, LocalizedText value);
+        void WriteLocalizedText(string? fieldName, LocalizedText? value);
 
-        void WriteExtensionObject(string fieldName, ExtensionObject value);
+        void WriteExtensionObject(string? fieldName, ExtensionObject? value);
 
-        void WriteExtensionObject<T>(string fieldName, T value)
-            where T : class, IEncodable;
+        void WriteExtensionObject<T>(string? fieldName, T value)
+            where T : class?, IEncodable;
 
-        void WriteDataValue(string fieldName, DataValue value);
+        void WriteDataValue(string? fieldName, DataValue? value);
 
-        void WriteVariant(string fieldName, Variant value);
+        void WriteVariant(string? fieldName, Variant value);
 
-        void WriteDiagnosticInfo(string fieldName, DiagnosticInfo value);
+        void WriteDiagnosticInfo(string? fieldName, DiagnosticInfo? value);
 
-        void WriteEncodable<T>(string fieldName, T value)
-            where T : class, IEncodable;
+        void WriteEncodable<T>(string? fieldName, T value)
+            where T : class?, IEncodable;
 
-        void WriteEnumeration<T>(string fieldName, T value)
+        void WriteEnumeration<T>(string? fieldName, T value)
             where T : struct, IConvertible;
 
-        void WriteBooleanArray(string fieldName, bool[] values);
+        void WriteBooleanArray(string? fieldName, bool[]? values);
 
-        void WriteSByteArray(string fieldName, sbyte[] values);
+        void WriteSByteArray(string? fieldName, sbyte[]? values);
 
-        void WriteByteArray(string fieldName, byte[] values);
+        void WriteByteArray(string? fieldName, byte[]? values);
 
-        void WriteInt16Array(string fieldName, short[] values);
+        void WriteInt16Array(string? fieldName, short[]? values);
 
-        void WriteUInt16Array(string fieldName, ushort[] values);
+        void WriteUInt16Array(string? fieldName, ushort[]? values);
 
-        void WriteInt32Array(string fieldName, int[] values);
+        void WriteInt32Array(string? fieldName, int[]? values);
 
-        void WriteUInt32Array(string fieldName, uint[] values);
+        void WriteUInt32Array(string? fieldName, uint[]? values);
 
-        void WriteInt64Array(string fieldName, long[] values);
+        void WriteInt64Array(string? fieldName, long[]? values);
 
-        void WriteUInt64Array(string fieldName, ulong[] values);
+        void WriteUInt64Array(string? fieldName, ulong[]? values);
 
-        void WriteFloatArray(string fieldName, float[] values);
+        void WriteFloatArray(string? fieldName, float[]? values);
 
-        void WriteDoubleArray(string fieldName, double[] values);
+        void WriteDoubleArray(string? fieldName, double[]? values);
 
-        void WriteStringArray(string fieldName, string[] values);
+        void WriteStringArray(string? fieldName, string[]? values);
 
-        void WriteDateTimeArray(string fieldName, DateTime[] values);
+        void WriteDateTimeArray(string? fieldName, DateTime[]? values);
 
-        void WriteGuidArray(string fieldName, Guid[] values);
+        void WriteGuidArray(string? fieldName, Guid[]? values);
 
-        void WriteByteStringArray(string fieldName, byte[][] values);
+        void WriteByteStringArray(string? fieldName, byte[]?[]? values);
 
-        void WriteXElementArray(string fieldName, XElement[] values);
+        void WriteXElementArray(string? fieldName, XElement?[]? values);
 
-        void WriteNodeIdArray(string fieldName, NodeId[] values);
+        void WriteNodeIdArray(string? fieldName, NodeId?[]? values);
 
-        void WriteExpandedNodeIdArray(string fieldName, ExpandedNodeId[] values);
+        void WriteExpandedNodeIdArray(string? fieldName, ExpandedNodeId?[]? values);
 
-        void WriteStatusCodeArray(string fieldName, StatusCode[] values);
+        void WriteStatusCodeArray(string? fieldName, StatusCode[]? values);
 
-        void WriteQualifiedNameArray(string fieldName, QualifiedName[] values);
+        void WriteQualifiedNameArray(string? fieldName, QualifiedName?[]? values);
 
-        void WriteLocalizedTextArray(string fieldName, LocalizedText[] values);
+        void WriteLocalizedTextArray(string? fieldName, LocalizedText?[]? values);
 
-        void WriteExtensionObjectArray(string fieldName, ExtensionObject[] values);
+        void WriteExtensionObjectArray(string? fieldName, ExtensionObject?[]? values);
 
-        void WriteExtensionObjectArray<T>(string fieldName, T[] values)
-            where T : class, IEncodable;
+        void WriteExtensionObjectArray<T>(string? fieldName, T[]? values)
+            where T : class?, IEncodable;
 
-        void WriteDataValueArray(string fieldName, DataValue[] values);
+        void WriteDataValueArray(string? fieldName, DataValue?[]? values);
 
-        void WriteVariantArray(string fieldName, Variant[] values);
+        void WriteVariantArray(string? fieldName, Variant[]? values);
 
-        void WriteDiagnosticInfoArray(string fieldName, DiagnosticInfo[] values);
+        void WriteDiagnosticInfoArray(string? fieldName, DiagnosticInfo?[]? values);
 
-        void WriteEncodableArray<T>(string fieldName, T[] values)
-            where T : class, IEncodable;
+        void WriteEncodableArray<T>(string? fieldName, T[]? values)
+            where T : class?, IEncodable;
 
         void WriteEnumerationArray<T>(string fieldName, T[] values)
             where T : struct, IConvertible;

--- a/UaClient/ServiceModel/Ua/Variant.cs
+++ b/UaClient/ServiceModel/Ua/Variant.cs
@@ -607,7 +607,7 @@ namespace Workstation.ServiceModel.Ua
             }
         }
 
-        public Variant(string[]? value)
+        public Variant(string?[]? value)
         {
             if (value is null)
             {
@@ -664,7 +664,7 @@ namespace Workstation.ServiceModel.Ua
             }
         }
 
-        public Variant(byte[][]? value)
+        public Variant(byte[]?[]? value)
         {
             if (value is null)
             {
@@ -683,7 +683,7 @@ namespace Workstation.ServiceModel.Ua
             }
         }
 
-        public Variant(XElement[]? value)
+        public Variant(XElement?[]? value)
         {
             if (value is null)
             {
@@ -797,7 +797,7 @@ namespace Workstation.ServiceModel.Ua
             }
         }
 
-        public Variant(ExtensionObject[]? value)
+        public Variant(ExtensionObject?[]? value)
         {
             if (value is null)
             {


### PR DESCRIPTION
In some cases a malicious server could have caused a null reference exception. This should be now fixed and cause a `ServiceResultException`.