### PR TITLE
[Discussion] Introduce EncodingMap

### DIFF
--- a/UaClient/ServiceModel/Ua/Channels/BinaryEncodingMap.cs
+++ b/UaClient/ServiceModel/Ua/Channels/BinaryEncodingMap.cs
@@ -1,0 +1,41 @@
+﻿// Copyright (c) Converter Systems LLC. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+
+namespace Workstation.ServiceModel.Ua.Channels
+{
+    public class BinaryEncodingMap : EncodingMap
+    {
+        private static readonly Dictionary<NodeId, Type> BinaryEncodingIdToTypeDictionary = new Dictionary<NodeId, Type>();
+        private static readonly Dictionary<Type, NodeId> TypeToBinaryEncodingIdDictionary = new Dictionary<Type, NodeId>();
+
+        static BinaryEncodingMap()
+        {
+            foreach (var type in typeof(OpenSecureChannelRequest).GetTypeInfo().Assembly.ExportedTypes)
+            {
+                var info = type.GetTypeInfo();
+                if (info.ImplementedInterfaces.Contains(typeof(IEncodable)))
+                {
+                    var attr = info.GetCustomAttribute<BinaryEncodingIdAttribute>(false);
+                    if (attr != null)
+                    {
+                        var id = ExpandedNodeId.ToNodeId(attr.NodeId, null);
+                        BinaryEncodingIdToTypeDictionary[id] = type;
+                        TypeToBinaryEncodingIdDictionary[type] = id;
+                    }
+                }
+            }
+        }
+
+        public BinaryEncodingMap() : base(
+            new [] { "http://opcfoundation.org/UA/" },
+            BinaryEncodingIdToTypeDictionary,
+            TypeToBinaryEncodingIdDictionary)
+        {
+        }
+    }
+}

--- a/UaClient/ServiceModel/Ua/EncodingMap.cs
+++ b/UaClient/ServiceModel/Ua/EncodingMap.cs
@@ -1,0 +1,47 @@
+﻿// Copyright (c) Converter Systems LLC. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Collections.Generic;
+
+namespace Workstation.ServiceModel.Ua
+{
+    public class EncodingMap : IEncodingMap
+    {
+        private readonly Dictionary<NodeId, Type> encodingIdToTypeDictionary;
+        private readonly Dictionary<Type, NodeId> typeToEncodingIdDictionary;
+
+        public List<string> NamespaceUris { get; }
+
+        public EncodingMap(IEnumerable<string> namespaceUris, IDictionary<NodeId, Type> encodingIdToTypeDictionary, IDictionary<Type, NodeId> typeToEncodingIdDictionary)
+        {
+            this.NamespaceUris = new List<string>(namespaceUris);
+            this.encodingIdToTypeDictionary = new Dictionary<NodeId, Type>(encodingIdToTypeDictionary);
+            this.typeToEncodingIdDictionary = new Dictionary<Type, NodeId>(typeToEncodingIdDictionary);
+        }
+
+        /// <inheritdoc />
+        public bool TryGetEncodingId(Type type, out NodeId encodingId)
+        {
+            return this.typeToEncodingIdDictionary.TryGetValue(type, out encodingId);
+        }
+
+        /// <inheritdoc />
+        public bool TryGetType(NodeId encodingId, out Type type)
+        {
+            return this.encodingIdToTypeDictionary.TryGetValue(encodingId, out type);
+        }
+
+        public void Add(NodeId encodingId, Type type)
+        {
+            this.typeToEncodingIdDictionary[type] = encodingId;
+            this.encodingIdToTypeDictionary[encodingId] = type;
+        }
+        
+        public void Add(ExpandedNodeId nodeId, Type type)
+        {
+            var encodingId = ExpandedNodeId.ToNodeId(nodeId, this.NamespaceUris);
+            this.Add(encodingId, type);
+        }
+    }
+}

--- a/UaClient/ServiceModel/Ua/IEncodingMap.cs
+++ b/UaClient/ServiceModel/Ua/IEncodingMap.cs
@@ -1,0 +1,32 @@
+﻿// Copyright (c) Converter Systems LLC. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Collections.Generic;
+
+namespace Workstation.ServiceModel.Ua
+{
+    public interface IEncodingMap
+    {
+        /// <summary>
+        /// Gets the namespace uris.
+        /// </summary>
+        List<string> NamespaceUris { get; }
+        
+        /// <summary>
+        /// Gets the system type associated with the encoding ID.
+        /// </summary>
+        /// <param name="encodingId">The encoding ID.</param>
+        /// <param name="type">The system type.</param>
+        /// <returns>True if successfull.</returns>
+        bool TryGetType(NodeId encodingId, out Type type);
+
+        /// <summary>
+        /// Gets the encoding ID associated with the system type.
+        /// </summary>
+        /// <param name="type">The system type.</param>
+        /// <param name="encodingId">The encoding ID.</param>
+        /// <returns>True if successfull.</returns>
+        bool TryGetEncodingId(Type type, out NodeId encodingId);
+    }
+}


### PR DESCRIPTION
As already discussed in #111 this PR shows a way to decouple the `BinaryEncoder` and `BinaryDecoder` from the `UaTcpSecureChannel ` by introducing the `IEncodingMap` interface. This will make the encoding and decoding of `ExtensionObject`s testable, as well as the implementation of the `EncodingMap` and `BinaryEncodingMap` itself.

I used here the word `EncodingMap` for the interface. I took some time to find a name that brings the formely `TryGet...()` methods and the `NamespaceUris` together. But I'm quite happy now with it. Other OPC UA implementations use the word "context", but I find this word a little bit vague.

This PR is thought as discussion base. If you like it, I can retrofit it on the `nullable-reference-types` branch. Since it contains breaking changes it should not be added in pre 3.0 version.