### PR TITLE
Add nullable reference type annotations to the tcp channels

### DIFF
--- a/UaClient/ServiceModel/Ua/Channels/BinaryDecoder.cs
+++ b/UaClient/ServiceModel/Ua/Channels/BinaryDecoder.cs
@@ -653,14 +653,13 @@ namespace Workstation.ServiceModel.Ua.Channels
 
         public ExtensionObject? ReadExtensionObject(string? fieldName)
         {
-            Type type;
             NodeId nodeId = this.ReadNodeId(null);
             byte b = this.reader.ReadByte();
             if (b == (byte)BodyType.ByteString) // BodyType Encodable is encoded as ByteString.
             {
                 ExpandedNodeId binaryEncodingId = NodeId.ToExpandedNodeId(nodeId, this.channel?.NamespaceUris);
 
-                if (this.channel != null && this.channel.TryGetTypeFromEncodingId(nodeId, out type))
+                if (this.channel != null && this.channel.TryGetTypeFromEncodingId(nodeId, out var type))
                 {
                     var len = this.ReadInt32(null);
                     var encodable = (IEncodable)Activator.CreateInstance(type)!;
@@ -687,7 +686,7 @@ namespace Workstation.ServiceModel.Ua.Channels
             byte b = this.reader.ReadByte();
             if (b == (byte)BodyType.ByteString)
             {
-                if (this.channel == null || !this.channel.TryGetTypeFromEncodingId(nodeId, out Type type))
+                if (this.channel == null || !this.channel.TryGetTypeFromEncodingId(nodeId, out var type))
                 {
                     throw new ServiceResultException(StatusCodes.BadDecodingError);
                 }

--- a/UaClient/ServiceModel/Ua/Channels/BinaryEncoder.cs
+++ b/UaClient/ServiceModel/Ua/Channels/BinaryEncoder.cs
@@ -886,7 +886,7 @@ namespace Workstation.ServiceModel.Ua.Channels
             }
 
             var type = value.GetType();
-            if (this.channel is null || !this.channel.TryGetBinaryEncodingIdFromType(type, out NodeId binaryEncodingId))
+            if (this.channel is null || !this.channel.TryGetBinaryEncodingIdFromType(type, out var binaryEncodingId))
             {
                 throw new ServiceResultException(StatusCodes.BadEncodingError);
             }

--- a/UaClient/ServiceModel/Ua/Channels/UaTcpMessageTypes.cs
+++ b/UaClient/ServiceModel/Ua/Channels/UaTcpMessageTypes.cs
@@ -1,6 +1,8 @@
 ﻿// Copyright (c) Converter Systems LLC. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+#nullable enable
+
 namespace Workstation.ServiceModel.Ua
 {
     public static class UaTcpMessageTypes

--- a/UaClient/ServiceModel/Ua/Channels/UaTcpSessionChannel.cs
+++ b/UaClient/ServiceModel/Ua/Channels/UaTcpSessionChannel.cs
@@ -12,6 +12,8 @@ using Org.BouncyCastle.Crypto;
 using Org.BouncyCastle.Security;
 using System.Collections.Generic;
 
+#nullable enable
+
 namespace Workstation.ServiceModel.Ua.Channels
 {
     /// <summary>
@@ -43,13 +45,13 @@ namespace Workstation.ServiceModel.Ua.Channels
         private const int NonceLength = 32;
         private const uint PublishTimeoutHint = 10 * 60 * 1000; // 10 minutes
 
-        private readonly ILoggerFactory loggerFactory;
-        private readonly ILogger logger;
+        private readonly ILoggerFactory? loggerFactory;
+        private readonly ILogger? logger;
         private readonly BroadcastBlock<PublishResponse> publishResponses;
         private readonly ActionBlock<PublishResponse> actionBlock;
         private readonly UaTcpSessionChannelOptions options;
         private readonly CancellationTokenSource stateMachineCts;
-        private Task stateMachineTask;
+        private Task? stateMachineTask;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="UaTcpSessionChannel"/> class.
@@ -63,12 +65,12 @@ namespace Workstation.ServiceModel.Ua.Channels
         /// <param name="additionalTypes">Any additional types to be registered with encoder.</param>
         public UaTcpSessionChannel(
             ApplicationDescription localDescription,
-            ICertificateStore certificateStore,
+            ICertificateStore? certificateStore,
             IUserIdentity userIdentity,
             EndpointDescription remoteEndpoint,
-            ILoggerFactory loggerFactory = null,
-            UaTcpSessionChannelOptions options = null,
-            IEnumerable<Type> additionalTypes = null)
+            ILoggerFactory? loggerFactory = null,
+            UaTcpSessionChannelOptions? options = null,
+            IEnumerable<Type>? additionalTypes = null)
             : base(localDescription, certificateStore, remoteEndpoint, loggerFactory, options, additionalTypes)
         {
             this.UserIdentity = userIdentity;
@@ -93,13 +95,13 @@ namespace Workstation.ServiceModel.Ua.Channels
         /// <param name="additionalTypes">Any additional types to be registered with encoder.</param>
         public UaTcpSessionChannel(
             ApplicationDescription localDescription,
-            ICertificateStore certificateStore,
-            IUserIdentity userIdentity,
+            ICertificateStore? certificateStore,
+            IUserIdentity? userIdentity,
             string endpointUrl,
-            string securityPolicyUri = null,
-            ILoggerFactory loggerFactory = null,
-            UaTcpSessionChannelOptions options = null,
-            IEnumerable<Type> additionalTypes = null)
+            string? securityPolicyUri = null,
+            ILoggerFactory? loggerFactory = null,
+            UaTcpSessionChannelOptions? options = null,
+            IEnumerable<Type>? additionalTypes = null)
             : base(localDescription, certificateStore, new EndpointDescription { EndpointUrl = endpointUrl, SecurityPolicyUri = securityPolicyUri }, loggerFactory, options, additionalTypes)
         {
             this.UserIdentity = userIdentity;
@@ -123,12 +125,12 @@ namespace Workstation.ServiceModel.Ua.Channels
         /// <param name="additionalTypes">Any additional types to be registered with encoder.</param>
         public UaTcpSessionChannel(
             ApplicationDescription localDescription,
-            ICertificateStore certificateStore,
-            Func<EndpointDescription, Task<IUserIdentity>> userIdentityProvider,
+            ICertificateStore? certificateStore,
+            Func<EndpointDescription, Task<IUserIdentity>>? userIdentityProvider,
             EndpointDescription remoteEndpoint,
-            ILoggerFactory loggerFactory = null,
-            UaTcpSessionChannelOptions options = null,
-            IEnumerable<Type> additionalTypes = null)
+            ILoggerFactory? loggerFactory = null,
+            UaTcpSessionChannelOptions? options = null,
+            IEnumerable<Type>? additionalTypes = null)
             : base(localDescription, certificateStore, remoteEndpoint, loggerFactory, options, additionalTypes)
         {
             this.UserIdentityProvider = userIdentityProvider;
@@ -156,10 +158,10 @@ namespace Workstation.ServiceModel.Ua.Channels
             ICertificateStore certificateStore,
             Func<EndpointDescription, Task<IUserIdentity>> userIdentityProvider,
             string endpointUrl,
-            string securityPolicyUri = null,
-            ILoggerFactory loggerFactory = null,
-            UaTcpSessionChannelOptions options = null,
-            IEnumerable<Type> additionalTypes = null)
+            string? securityPolicyUri = null,
+            ILoggerFactory? loggerFactory = null,
+            UaTcpSessionChannelOptions? options = null,
+            IEnumerable<Type>? additionalTypes = null)
             : base(localDescription, certificateStore, new EndpointDescription { EndpointUrl = endpointUrl, SecurityPolicyUri = securityPolicyUri }, loggerFactory, options, additionalTypes)
         {
             this.UserIdentityProvider = userIdentityProvider;
@@ -174,22 +176,22 @@ namespace Workstation.ServiceModel.Ua.Channels
         /// <summary>
         /// Gets the asynchronous function that provides the user identity. Provide an <see cref="AnonymousIdentity"/>, <see cref="UserNameIdentity"/>, <see cref="IssuedIdentity"/> or <see cref="X509Identity"/>
         /// </summary>
-        public Func<EndpointDescription, Task<IUserIdentity>> UserIdentityProvider { get; }
+        public Func<EndpointDescription, Task<IUserIdentity>>? UserIdentityProvider { get; }
 
         /// <summary>
         /// Gets the user identity.
         /// </summary>
-        public IUserIdentity UserIdentity { get; private set; }
+        public IUserIdentity? UserIdentity { get; private set; }
 
         /// <summary>
         /// Gets the session id provided by the server.
         /// </summary>
-        public NodeId SessionId { get; private set; }
+        public NodeId? SessionId { get; private set; }
 
         /// <summary>
         /// Gets the remote nonce provided by the server.
         /// </summary>
-        public byte[] RemoteNonce { get; private set; }
+        public byte[]? RemoteNonce { get; private set; }
 
         /// <summary>
         /// Gets a Task that represents the asynchronous operation and completion of the channel.
@@ -262,8 +264,15 @@ namespace Workstation.ServiceModel.Ua.Channels
                     }
 
                     var selectedEndpoint = getEndpointsResponse.Endpoints
+                        .OfType<EndpointDescription>()
                         .Where(e => string.IsNullOrEmpty(securityPolicyUri) || e.SecurityPolicyUri == securityPolicyUri)
-                        .OrderBy(e => e.SecurityLevel).Last();
+                        .OrderBy(e => e.SecurityLevel)
+                        .LastOrDefault();
+
+                    if (selectedEndpoint is null)
+                    {
+                        throw new InvalidOperationException($"'{endpointUrl}' returned no endpoint for the requested security policy '{securityPolicyUri}'.");
+                    }
 
                     this.RemoteEndpoint.Server = selectedEndpoint.Server;
                     this.RemoteEndpoint.ServerCertificate = selectedEndpoint.ServerCertificate;
@@ -332,7 +341,7 @@ namespace Workstation.ServiceModel.Ua.Channels
                 }
 
                 // verify the server's signature.
-                ISigner verifier = null;
+                ISigner? verifier = null;
                 bool verified = false;
 
                 switch (this.RemoteEndpoint.SecurityPolicyUri)
@@ -341,26 +350,26 @@ namespace Workstation.ServiceModel.Ua.Channels
                     case SecurityPolicyUris.Basic256:
                         verifier = SignerUtilities.GetSigner("SHA-1withRSA");
                         verifier.Init(false, this.RemotePublicKey);
-                        verifier.BlockUpdate(localCertificate, 0, localCertificate.Length);
-                        verifier.BlockUpdate(localNonce, 0, localNonce.Length);
-                        verified = verifier.VerifySignature(createSessionResponse.ServerSignature.Signature);
+                        verifier.BlockUpdate(localCertificate, 0, localCertificate!.Length);
+                        verifier.BlockUpdate(localNonce, 0, localNonce!.Length);
+                        verified = verifier.VerifySignature(createSessionResponse.ServerSignature!.Signature);
                         break;
 
                     case SecurityPolicyUris.Basic256Sha256:
                     case SecurityPolicyUris.Aes128_Sha256_RsaOaep:
                         verifier = SignerUtilities.GetSigner("SHA-256withRSA");
                         verifier.Init(false, this.RemotePublicKey);
-                        verifier.BlockUpdate(localCertificate, 0, localCertificate.Length);
-                        verifier.BlockUpdate(localNonce, 0, localNonce.Length);
-                        verified = verifier.VerifySignature(createSessionResponse.ServerSignature.Signature);
+                        verifier.BlockUpdate(localCertificate, 0, localCertificate!.Length);
+                        verifier.BlockUpdate(localNonce, 0, localNonce!.Length);
+                        verified = verifier.VerifySignature(createSessionResponse.ServerSignature!.Signature);
                         break;
 
                     case SecurityPolicyUris.Aes256_Sha256_RsaPss:
                         verifier = SignerUtilities.GetSigner("SHA-256withRSAandMGF1");
                         verifier.Init(false, this.RemotePublicKey);
-                        verifier.BlockUpdate(localCertificate, 0, localCertificate.Length);
-                        verifier.BlockUpdate(localNonce, 0, localNonce.Length);
-                        verified = verifier.VerifySignature(createSessionResponse.ServerSignature.Signature);
+                        verifier.BlockUpdate(localCertificate, 0, localCertificate!.Length);
+                        verifier.BlockUpdate(localNonce, 0, localNonce!.Length);
+                        verified = verifier.VerifySignature(createSessionResponse.ServerSignature!.Signature);
                         break;
 
                     default:
@@ -376,8 +385,8 @@ namespace Workstation.ServiceModel.Ua.Channels
             }
 
             // create client signature
-            SignatureData clientSignature = null;
-            ISigner signer = null;
+            SignatureData? clientSignature = null;
+            ISigner? signer = null;
 
             switch (this.RemoteEndpoint.SecurityPolicyUri)
             {
@@ -385,8 +394,8 @@ namespace Workstation.ServiceModel.Ua.Channels
                 case SecurityPolicyUris.Basic256:
                     signer = SignerUtilities.GetSigner("SHA-1withRSA");
                     signer.Init(true, this.LocalPrivateKey);
-                    signer.BlockUpdate(this.RemoteEndpoint.ServerCertificate, 0, this.RemoteEndpoint.ServerCertificate.Length);
-                    signer.BlockUpdate(this.RemoteNonce, 0, this.RemoteNonce.Length);
+                    signer.BlockUpdate(this.RemoteEndpoint.ServerCertificate, 0, this.RemoteEndpoint.ServerCertificate!.Length);
+                    signer.BlockUpdate(this.RemoteNonce, 0, this.RemoteNonce!.Length);
                     clientSignature = new SignatureData
                     {
                         Signature = signer.GenerateSignature(),
@@ -399,8 +408,8 @@ namespace Workstation.ServiceModel.Ua.Channels
                 case SecurityPolicyUris.Aes128_Sha256_RsaOaep:
                     signer = SignerUtilities.GetSigner("SHA-256withRSA");
                     signer.Init(true, this.LocalPrivateKey);
-                    signer.BlockUpdate(this.RemoteEndpoint.ServerCertificate, 0, this.RemoteEndpoint.ServerCertificate.Length);
-                    signer.BlockUpdate(this.RemoteNonce, 0, this.RemoteNonce.Length);
+                    signer.BlockUpdate(this.RemoteEndpoint.ServerCertificate, 0, this.RemoteEndpoint.ServerCertificate!.Length);
+                    signer.BlockUpdate(this.RemoteNonce, 0, this.RemoteNonce!.Length);
                     clientSignature = new SignatureData
                     {
                         Signature = signer.GenerateSignature(),
@@ -412,8 +421,8 @@ namespace Workstation.ServiceModel.Ua.Channels
                 case SecurityPolicyUris.Aes256_Sha256_RsaPss:
                     signer = SignerUtilities.GetSigner("SHA-256withRSAandMGF1");
                     signer.Init(true, this.LocalPrivateKey);
-                    signer.BlockUpdate(this.RemoteEndpoint.ServerCertificate, 0, this.RemoteEndpoint.ServerCertificate.Length);
-                    signer.BlockUpdate(this.RemoteNonce, 0, this.RemoteNonce.Length);
+                    signer.BlockUpdate(this.RemoteEndpoint.ServerCertificate, 0, this.RemoteEndpoint.ServerCertificate!.Length);
+                    signer.BlockUpdate(this.RemoteNonce, 0, this.RemoteNonce!.Length);
                     clientSignature = new SignatureData
                     {
                         Signature = signer.GenerateSignature(),
@@ -430,20 +439,19 @@ namespace Workstation.ServiceModel.Ua.Channels
             signer = null;
 
             // supported UserIdentityToken types are AnonymousIdentityToken, UserNameIdentityToken, IssuedIdentityToken, X509IdentityToken
-            UserIdentityToken identityToken = null;
-            SignatureData tokenSignature = null;
+            UserIdentityToken? identityToken = null;
+            SignatureData? tokenSignature = null;
 
             // if UserIdentity type is IssuedIdentity
-            if (this.UserIdentity is IssuedIdentity)
+            if (this.UserIdentity is IssuedIdentity issuedIdentity)
             {
-                var tokenPolicy = this.RemoteEndpoint.UserIdentityTokens.FirstOrDefault(t => t.TokenType == UserTokenType.IssuedToken);
+                var tokenPolicy = this.RemoteEndpoint.UserIdentityTokens.FirstOrDefault(t => t?.TokenType == UserTokenType.IssuedToken);
                 if (tokenPolicy == null)
                 {
                     throw new ServiceResultException(StatusCodes.BadIdentityTokenRejected);
                 }
 
-                var issuedIdentity = (IssuedIdentity)this.UserIdentity;
-                int plainTextLength = issuedIdentity.TokenData.Length + this.RemoteNonce.Length;
+                int plainTextLength = issuedIdentity.TokenData.Length + this.RemoteNonce!.Length;
                 IBufferedCipher encryptor;
                 byte[] cipherText;
                 int pos;
@@ -512,20 +520,17 @@ namespace Workstation.ServiceModel.Ua.Channels
                 }
 
                 tokenSignature = new SignatureData();
-                encryptor = null;
-                cipherText = null;
             }
 
             // if UserIdentity type is X509Identity
-            else if (this.UserIdentity is X509Identity)
+            else if (this.UserIdentity is X509Identity x509Identity)
             {
-                var tokenPolicy = this.RemoteEndpoint.UserIdentityTokens.FirstOrDefault(t => t.TokenType == UserTokenType.Certificate);
+                var tokenPolicy = this.RemoteEndpoint.UserIdentityTokens.FirstOrDefault(t => t?.TokenType == UserTokenType.Certificate);
                 if (tokenPolicy == null)
                 {
                     throw new ServiceResultException(StatusCodes.BadIdentityTokenRejected);
                 }
 
-                var x509Identity = (X509Identity)this.UserIdentity;
                 identityToken = new X509IdentityToken { CertificateData = x509Identity.Certificate?.GetEncoded(), PolicyId = tokenPolicy.PolicyId };
 
                 var secPolicyUri = tokenPolicy.SecurityPolicyUri ?? this.RemoteEndpoint.SecurityPolicyUri;
@@ -536,8 +541,8 @@ namespace Workstation.ServiceModel.Ua.Channels
                     case SecurityPolicyUris.Basic256:
                         signer = SignerUtilities.GetSigner("SHA-1withRSA");
                         signer.Init(true, x509Identity.PrivateKey);
-                        signer.BlockUpdate(this.RemoteEndpoint.ServerCertificate, 0, this.RemoteEndpoint.ServerCertificate.Length);
-                        signer.BlockUpdate(this.RemoteNonce, 0, this.RemoteNonce.Length);
+                        signer.BlockUpdate(this.RemoteEndpoint.ServerCertificate, 0, this.RemoteEndpoint.ServerCertificate!.Length);
+                        signer.BlockUpdate(this.RemoteNonce, 0, this.RemoteNonce!.Length);
                         tokenSignature = new SignatureData
                         {
                             Signature = signer.GenerateSignature(),
@@ -550,8 +555,8 @@ namespace Workstation.ServiceModel.Ua.Channels
                     case SecurityPolicyUris.Aes128_Sha256_RsaOaep:
                         signer = SignerUtilities.GetSigner("SHA-256withRSA");
                         signer.Init(true, x509Identity.PrivateKey);
-                        signer.BlockUpdate(this.RemoteEndpoint.ServerCertificate, 0, this.RemoteEndpoint.ServerCertificate.Length);
-                        signer.BlockUpdate(this.RemoteNonce, 0, this.RemoteNonce.Length);
+                        signer.BlockUpdate(this.RemoteEndpoint.ServerCertificate, 0, this.RemoteEndpoint.ServerCertificate!.Length);
+                        signer.BlockUpdate(this.RemoteNonce, 0, this.RemoteNonce!.Length);
                         tokenSignature = new SignatureData
                         {
                             Signature = signer.GenerateSignature(),
@@ -562,8 +567,8 @@ namespace Workstation.ServiceModel.Ua.Channels
                     case SecurityPolicyUris.Aes256_Sha256_RsaPss:
                         signer = SignerUtilities.GetSigner("SHA-256withRSAandMGF1");
                         signer.Init(true, x509Identity.PrivateKey);
-                        signer.BlockUpdate(this.RemoteEndpoint.ServerCertificate, 0, this.RemoteEndpoint.ServerCertificate.Length);
-                        signer.BlockUpdate(this.RemoteNonce, 0, this.RemoteNonce.Length);
+                        signer.BlockUpdate(this.RemoteEndpoint.ServerCertificate, 0, this.RemoteEndpoint.ServerCertificate!.Length);
+                        signer.BlockUpdate(this.RemoteNonce, 0, this.RemoteNonce!.Length);
                         tokenSignature = new SignatureData
                         {
                             Signature = signer.GenerateSignature(),
@@ -580,17 +585,16 @@ namespace Workstation.ServiceModel.Ua.Channels
             }
 
             // if UserIdentity type is UserNameIdentity
-            else if (this.UserIdentity is UserNameIdentity)
+            else if (this.UserIdentity is UserNameIdentity userNameIdentity)
             {
-                var tokenPolicy = this.RemoteEndpoint.UserIdentityTokens.FirstOrDefault(t => t.TokenType == UserTokenType.UserName);
+                var tokenPolicy = this.RemoteEndpoint.UserIdentityTokens.FirstOrDefault(t => t?.TokenType == UserTokenType.UserName);
                 if (tokenPolicy == null)
                 {
                     throw new ServiceResultException(StatusCodes.BadIdentityTokenRejected);
                 }
 
-                var userNameIdentity = (UserNameIdentity)this.UserIdentity;
                 byte[] passwordBytes = userNameIdentity.Password != null ? System.Text.Encoding.UTF8.GetBytes(userNameIdentity.Password) : new byte[0];
-                int plainTextLength = passwordBytes.Length + this.RemoteNonce.Length;
+                int plainTextLength = passwordBytes.Length + this.RemoteNonce!.Length;
                 IBufferedCipher encryptor;
                 byte[] cipherText;
                 int pos;
@@ -663,15 +667,12 @@ namespace Workstation.ServiceModel.Ua.Channels
                 }
 
                 tokenSignature = new SignatureData();
-                passwordBytes = null;
-                encryptor = null;
-                cipherText = null;
             }
 
             // if UserIdentity type is AnonymousIdentity or null
             else
             {
-                var tokenPolicy = this.RemoteEndpoint.UserIdentityTokens.FirstOrDefault(t => t.TokenType == UserTokenType.Anonymous);
+                var tokenPolicy = this.RemoteEndpoint.UserIdentityTokens.FirstOrDefault(t => t?.TokenType == UserTokenType.Anonymous);
                 if (tokenPolicy == null)
                 {
                     throw new ServiceResultException(StatusCodes.BadIdentityTokenRejected);
@@ -711,18 +712,24 @@ namespace Workstation.ServiceModel.Ua.Channels
             };
 
             var readResponse = await this.ReadAsync(readRequest).ConfigureAwait(false);
-            if (readResponse.Results.Length == 2)
+            if (readResponse.Results?.Length == 2)
             {
-                if (StatusCode.IsGood(readResponse.Results[0].StatusCode))
+                if (readResponse.Results[0] is { } res0 && StatusCode.IsGood(res0.StatusCode))
                 {
                     this.NamespaceUris.Clear();
-                    this.NamespaceUris.AddRange(readResponse.Results[0].GetValueOrDefault<string[]>());
+                    if (res0.GetValueOrDefault<string[]>() is { } namespaceUris)
+                    {
+                        this.NamespaceUris.AddRange(namespaceUris);
+                    }
                 }
 
-                if (StatusCode.IsGood(readResponse.Results[1].StatusCode))
+                if (readResponse.Results[1] is { } res1 && StatusCode.IsGood(res1.StatusCode))
                 {
                     this.ServerUris.Clear();
-                    this.ServerUris.AddRange(readResponse.Results[1].GetValueOrDefault<string[]>());
+                    if (res1.GetValueOrDefault<string[]>() is { } serverUris)
+                    {
+                        this.ServerUris.AddRange(serverUris);
+                    }
                 }
             }
 
@@ -791,8 +798,21 @@ namespace Workstation.ServiceModel.Ua.Channels
 
                     publishRequest = new PublishRequest
                     {
-                        RequestHeader = new RequestHeader { TimeoutHint = PublishTimeoutHint, ReturnDiagnostics = this.options.DiagnosticsHint },
-                        SubscriptionAcknowledgements = publishResponse.NotificationMessage.NotificationData != null ? new[] { new SubscriptionAcknowledgement { SequenceNumber = publishResponse.NotificationMessage.SequenceNumber, SubscriptionId = publishResponse.SubscriptionId } } : new SubscriptionAcknowledgement[0]
+                        RequestHeader = new RequestHeader
+                        {
+                            TimeoutHint = PublishTimeoutHint,
+                            ReturnDiagnostics = this.options.DiagnosticsHint
+                        },
+                        SubscriptionAcknowledgements = publishResponse.NotificationMessage?.NotificationData != null
+                        ? new[] 
+                        { 
+                            new SubscriptionAcknowledgement
+                            {
+                                SequenceNumber = publishResponse.NotificationMessage.SequenceNumber,
+                                SubscriptionId = publishResponse.SubscriptionId
+                            }
+                        }
+                        : new SubscriptionAcknowledgement[0]
                     };
                 }
                 catch (Exception ex)

--- a/UaClient/ServiceModel/Ua/ServiceResult.cs
+++ b/UaClient/ServiceModel/Ua/ServiceResult.cs
@@ -40,7 +40,7 @@ namespace Workstation.ServiceModel.Ua
         /// <param name="code">A code.</param>
         /// <param name="diagnosticInfo">A diagnostic info.</param>
         /// <param name="stringTable">A string table.</param>
-        public ServiceResult(StatusCode code, DiagnosticInfo? diagnosticInfo, IList<string> stringTable)
+        public ServiceResult(StatusCode code, DiagnosticInfo? diagnosticInfo, IList<string?>? stringTable)
         {
             this.StatusCode = code;
 
@@ -69,7 +69,7 @@ namespace Workstation.ServiceModel.Ua
         /// <param name="index">An index.</param>
         /// <param name="diagnosticInfos">A diagnostic info array.</param>
         /// <param name="stringTable">A string table.</param>
-        public ServiceResult(StatusCode code, int index, DiagnosticInfo[] diagnosticInfos, IList<string> stringTable)
+        public ServiceResult(StatusCode code, int index, DiagnosticInfo[] diagnosticInfos, IList<string?>? stringTable)
         {
             this.StatusCode = code;
 
@@ -225,7 +225,7 @@ namespace Workstation.ServiceModel.Ua
         /// Looks up a string in a string table.
         /// </summary>
         /// <returns>A string.</returns>
-        private static string? LookupString(IList<string> stringTable, int index)
+        private static string? LookupString(IList<string?>? stringTable, int index)
         {
             if (stringTable == null || index < 0 || index >= stringTable.Count)
             {

--- a/UaClient/ServiceModel/Ua/UaApplication.cs
+++ b/UaClient/ServiceModel/Ua/UaApplication.cs
@@ -238,9 +238,9 @@ namespace Workstation.ServiceModel.Ua
                 this.logger?.LogTrace($"Begin creating UaTcpSessionChannel for {endpointUrl}");
                 await this.CheckSuspension(token).ConfigureAwait(false);
 
-                EndpointDescription? endpoint;
+                EndpointDescription endpoint;
                 var mappedEndpoint = this.MappedEndpoints?.LastOrDefault(m => m.RequestedUrl == endpointUrl);
-                if (mappedEndpoint != null)
+                if (mappedEndpoint?.Endpoint != null)
                 {
                     endpoint = mappedEndpoint.Endpoint;
                 }


### PR DESCRIPTION
This PR adds nullable annotations to the TCP channels. I had to insert the damnit operator at many places, because there are several variables that are assigned on opening and used later on, but they are null before that. Maybe, there are ways to work around that, but I just wanted to add the annotation and not to change the logic.

One thing that cannot be very well annotated is the nullabillity of properties. While it is very easy to create a response with a response header which is null (e.g.  `new BrowseResponse {}`), the response of an actual service request (e.g. `BrowseAsync(...)`) has always an non-null response header else the method would throw. But there is no way to describe this fact on a language level.