### PR TITLE
Develop

### DIFF
--- a/UaClient.UnitTests/IntegrationTests/IntegrationTests.cs
+++ b/UaClient.UnitTests/IntegrationTests/IntegrationTests.cs
@@ -262,6 +262,47 @@ namespace Workstation.UaClient.IntegrationTests
         }
 
         /// <summary>
+        /// Tests simulating a reconnect.
+        /// Only run this test with a running opc test server.
+        /// </summary>
+        /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
+        [Fact]
+        public async Task ConnectToExistingSession()
+        {
+
+            UaTcpSessionChannelReconnectParameter uaTcpSessionChannelReconnectParameter =
+                new UaTcpSessionChannelReconnectParameter();
+
+            var channel = new UaTcpSessionChannel(
+                this.localDescription,
+                this.certificateStore,
+                new AnonymousIdentity(),
+                EndpointUrl,
+                SecurityPolicyUris.None,
+                loggerFactory: this.loggerFactory);
+
+            await channel.OpenAsync();
+
+            uaTcpSessionChannelReconnectParameter.RemoteNonce = channel.RemoteNonce;
+            uaTcpSessionChannelReconnectParameter.AuthenticationToken = channel.AuthenticationToken;
+            uaTcpSessionChannelReconnectParameter.SessionId = channel.SessionId;
+
+            await channel.AbortAsync();
+
+            var channel2 = new UaTcpSessionChannel(
+                   this.localDescription,
+                   this.certificateStore,
+                   new AnonymousIdentity(),
+                   EndpointUrl,
+                   uaTcpSessionChannelReconnectParameter,
+                   SecurityPolicyUris.None,
+                   options: new UaTcpSessionChannelOptions { SessionTimeout = 120000 });
+
+            await channel2.OpenAsync();
+            await channel2.CloseAsync();
+        }
+
+        /// <summary>
         /// Tests read server status.
         /// Only run this test with a running opc test server.
         /// </summary>

--- a/UaClient/ServiceModel/Ua/Channels/UaTcpSessionChannel.cs
+++ b/UaClient/ServiceModel/Ua/Channels/UaTcpSessionChannel.cs
@@ -86,6 +86,40 @@ namespace Workstation.ServiceModel.Ua.Channels
         /// <param name="localDescription">The <see cref="ApplicationDescription"/> of the local application.</param>
         /// <param name="certificateStore">The local certificate store.</param>
         /// <param name="userIdentity">The user identity. Provide an <see cref="AnonymousIdentity"/>, <see cref="UserNameIdentity"/>, <see cref="IssuedIdentity"/> or <see cref="X509Identity"/>.</param>
+        /// <param name="remoteEndpoint">The <see cref="EndpointDescription"/> of the remote application. Obtained from a prior call to UaTcpDiscoveryClient.GetEndpoints.</param>
+        /// <param name="uaTcpSessionChannelReconnectParameter">Provides SessionId, RemoteNonce and AuthenticationToken for reconnecting to a session</param>
+        /// <param name="loggerFactory">The logger factory.</param>
+        /// <param name="options">The session channel options.</param>
+        /// <param name="additionalTypes">Any additional types to be registered with encoder.</param>
+        public UaTcpSessionChannel(
+            ApplicationDescription localDescription,
+            ICertificateStore certificateStore,
+            IUserIdentity userIdentity,
+            EndpointDescription remoteEndpoint,
+            UaTcpSessionChannelReconnectParameter uaTcpSessionChannelReconnectParameter,
+            ILoggerFactory loggerFactory = null,
+            UaTcpSessionChannelOptions options = null,
+            IEnumerable<Type> additionalTypes = null)
+            : base(localDescription, certificateStore, remoteEndpoint, loggerFactory, options, additionalTypes)
+        {
+            this.UserIdentity = userIdentity;
+            this.SessionId = uaTcpSessionChannelReconnectParameter.SessionId;
+            this.RemoteNonce = uaTcpSessionChannelReconnectParameter.RemoteNonce;
+            this.AuthenticationToken = uaTcpSessionChannelReconnectParameter.AuthenticationToken;
+            this.options = options ?? new UaTcpSessionChannelOptions();
+            this.loggerFactory = loggerFactory;
+            this.logger = loggerFactory?.CreateLogger<UaTcpSessionChannel>();
+            this.actionBlock = new ActionBlock<PublishResponse>(pr => this.OnPublishResponse(pr));
+            this.stateMachineCts = new CancellationTokenSource();
+            this.publishResponses = new BroadcastBlock<PublishResponse>(null, new DataflowBlockOptions { CancellationToken = this.stateMachineCts.Token });
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="UaTcpSessionChannel"/> class.
+        /// </summary>
+        /// <param name="localDescription">The <see cref="ApplicationDescription"/> of the local application.</param>
+        /// <param name="certificateStore">The local certificate store.</param>
+        /// <param name="userIdentity">The user identity. Provide an <see cref="AnonymousIdentity"/>, <see cref="UserNameIdentity"/>, <see cref="IssuedIdentity"/> or <see cref="X509Identity"/>.</param>
         /// <param name="endpointUrl">The url of the endpoint of the remote application</param>
         /// <param name="securityPolicyUri">Optionally, filter by SecurityPolicyUri.</param>
         /// <param name="loggerFactory">The logger factory.</param>
@@ -103,6 +137,42 @@ namespace Workstation.ServiceModel.Ua.Channels
             : base(localDescription, certificateStore, new EndpointDescription { EndpointUrl = endpointUrl, SecurityPolicyUri = securityPolicyUri }, loggerFactory, options, additionalTypes)
         {
             this.UserIdentity = userIdentity;
+            this.options = options ?? new UaTcpSessionChannelOptions();
+            this.loggerFactory = loggerFactory;
+            this.logger = loggerFactory?.CreateLogger<UaTcpSessionChannel>();
+            this.actionBlock = new ActionBlock<PublishResponse>(pr => this.OnPublishResponse(pr));
+            this.stateMachineCts = new CancellationTokenSource();
+            this.publishResponses = new BroadcastBlock<PublishResponse>(null, new DataflowBlockOptions { CancellationToken = this.stateMachineCts.Token });
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="UaTcpSessionChannel"/> class.
+        /// </summary>
+        /// <param name="localDescription">The <see cref="ApplicationDescription"/> of the local application.</param>
+        /// <param name="certificateStore">The local certificate store.</param>
+        /// <param name="userIdentity">The user identity. Provide an <see cref="AnonymousIdentity"/>, <see cref="UserNameIdentity"/>, <see cref="IssuedIdentity"/> or <see cref="X509Identity"/>.</param>
+        /// <param name="endpointUrl">The url of the endpoint of the remote application</param>
+        /// <param name="uaTcpSessionChannelReconnectParameter">Provides SessionId, RemoteNonce and AuthenticationToken for reconnecting to a session</param>
+        /// <param name="securityPolicyUri">Optionally, filter by SecurityPolicyUri.</param>
+        /// <param name="loggerFactory">The logger factory.</param>
+        /// <param name="options">The session channel options.</param>
+        /// <param name="additionalTypes">Any additional types to be registered with encoder.</param>
+        public UaTcpSessionChannel(
+            ApplicationDescription localDescription,
+            ICertificateStore certificateStore,
+            IUserIdentity userIdentity,
+            string endpointUrl,
+            UaTcpSessionChannelReconnectParameter uaTcpSessionChannelReconnectParameter,
+            string securityPolicyUri = null,
+            ILoggerFactory loggerFactory = null,
+            UaTcpSessionChannelOptions options = null,
+            IEnumerable<Type> additionalTypes = null)
+            : base(localDescription, certificateStore, new EndpointDescription { EndpointUrl = endpointUrl, SecurityPolicyUri = securityPolicyUri }, loggerFactory, options, additionalTypes)
+        {
+            this.UserIdentity = userIdentity;
+            this.SessionId = uaTcpSessionChannelReconnectParameter.SessionId;
+            this.RemoteNonce = uaTcpSessionChannelReconnectParameter.RemoteNonce;
+            this.AuthenticationToken = uaTcpSessionChannelReconnectParameter.AuthenticationToken;
             this.options = options ?? new UaTcpSessionChannelOptions();
             this.loggerFactory = loggerFactory;
             this.logger = loggerFactory?.CreateLogger<UaTcpSessionChannel>();
@@ -146,6 +216,40 @@ namespace Workstation.ServiceModel.Ua.Channels
         /// <param name="localDescription">The <see cref="ApplicationDescription"/> of the local application.</param>
         /// <param name="certificateStore">The local certificate store.</param>
         /// <param name="userIdentityProvider">An asynchronous function that provides the user identity. Provide an <see cref="AnonymousIdentity"/>, <see cref="UserNameIdentity"/>, <see cref="IssuedIdentity"/> or <see cref="X509Identity"/>.</param>
+        /// <param name="remoteEndpoint">The <see cref="EndpointDescription"/> of the remote application. Obtained from a prior call to UaTcpDiscoveryClient.GetEndpoints.</param>
+        /// <param name="uaTcpSessionChannelReconnectParameter">Provides SessionId, RemoteNonce and AuthenticationToken for reconnecting to a session</param>
+        /// <param name="loggerFactory">The logger factory.</param>
+        /// <param name="options">The session channel options.</param>
+        /// <param name="additionalTypes">Any additional types to be registered with encoder.</param>
+        public UaTcpSessionChannel(
+            ApplicationDescription localDescription,
+            ICertificateStore certificateStore,
+            Func<EndpointDescription, Task<IUserIdentity>> userIdentityProvider,
+            EndpointDescription remoteEndpoint,
+            UaTcpSessionChannelReconnectParameter uaTcpSessionChannelReconnectParameter,
+            ILoggerFactory loggerFactory = null,
+            UaTcpSessionChannelOptions options = null,
+            IEnumerable<Type> additionalTypes = null)
+            : base(localDescription, certificateStore, remoteEndpoint, loggerFactory, options, additionalTypes)
+        {
+            this.UserIdentityProvider = userIdentityProvider;
+            this.SessionId = uaTcpSessionChannelReconnectParameter.SessionId;
+            this.RemoteNonce = uaTcpSessionChannelReconnectParameter.RemoteNonce;
+            this.AuthenticationToken = uaTcpSessionChannelReconnectParameter.AuthenticationToken;
+            this.options = options ?? new UaTcpSessionChannelOptions();
+            this.loggerFactory = loggerFactory;
+            this.logger = loggerFactory?.CreateLogger<UaTcpSessionChannel>();
+            this.actionBlock = new ActionBlock<PublishResponse>(pr => this.OnPublishResponse(pr));
+            this.stateMachineCts = new CancellationTokenSource();
+            this.publishResponses = new BroadcastBlock<PublishResponse>(null, new DataflowBlockOptions { CancellationToken = this.stateMachineCts.Token });
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="UaTcpSessionChannel"/> class.
+        /// </summary>
+        /// <param name="localDescription">The <see cref="ApplicationDescription"/> of the local application.</param>
+        /// <param name="certificateStore">The local certificate store.</param>
+        /// <param name="userIdentityProvider">An asynchronous function that provides the user identity. Provide an <see cref="AnonymousIdentity"/>, <see cref="UserNameIdentity"/>, <see cref="IssuedIdentity"/> or <see cref="X509Identity"/>.</param>
         /// <param name="endpointUrl">The url of the endpoint of the remote application</param>
         /// <param name="securityPolicyUri">Optionally, filter by SecurityPolicyUri.</param>
         /// <param name="loggerFactory">The logger factory.</param>
@@ -170,6 +274,44 @@ namespace Workstation.ServiceModel.Ua.Channels
             this.stateMachineCts = new CancellationTokenSource();
             this.publishResponses = new BroadcastBlock<PublishResponse>(null, new DataflowBlockOptions { CancellationToken = this.stateMachineCts.Token });
         }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="UaTcpSessionChannel"/> class.
+        /// </summary>
+        /// <param name="localDescription">The <see cref="ApplicationDescription"/> of the local application.</param>
+        /// <param name="certificateStore">The local certificate store.</param>
+        /// <param name="userIdentityProvider">An asynchronous function that provides the user identity. Provide an <see cref="AnonymousIdentity"/>, <see cref="UserNameIdentity"/>, <see cref="IssuedIdentity"/> or <see cref="X509Identity"/>.</param>
+        /// <param name="endpointUrl">The url of the endpoint of the remote application</param>
+        /// <param name="uaTcpSessionChannelReconnectParameter">Provides SessionId, RemoteNonce and AuthenticationToken for reconnecting to a session</param>
+        /// <param name="securityPolicyUri">Optionally, filter by SecurityPolicyUri.</param>
+        /// <param name="loggerFactory">The logger factory.</param>
+        /// <param name="options">The session channel options.</param>
+        /// <param name="additionalTypes">Any additional types to be registered with encoder.</param>
+        public UaTcpSessionChannel(
+            ApplicationDescription localDescription,
+            ICertificateStore certificateStore,
+            Func<EndpointDescription, Task<IUserIdentity>> userIdentityProvider,
+            string endpointUrl,
+            UaTcpSessionChannelReconnectParameter uaTcpSessionChannelReconnectParameter,
+            string securityPolicyUri = null,
+            ILoggerFactory loggerFactory = null,
+            UaTcpSessionChannelOptions options = null,
+            IEnumerable<Type> additionalTypes = null)
+            : base(localDescription, certificateStore, new EndpointDescription { EndpointUrl = endpointUrl, SecurityPolicyUri = securityPolicyUri }, loggerFactory, options, additionalTypes)
+        {
+            this.UserIdentityProvider = userIdentityProvider;
+            this.SessionId = uaTcpSessionChannelReconnectParameter.SessionId;
+            this.RemoteNonce = uaTcpSessionChannelReconnectParameter.RemoteNonce;
+            this.AuthenticationToken = uaTcpSessionChannelReconnectParameter.AuthenticationToken;
+            this.options = options ?? new UaTcpSessionChannelOptions();
+            this.loggerFactory = loggerFactory;
+            this.logger = loggerFactory?.CreateLogger<UaTcpSessionChannel>();
+            this.actionBlock = new ActionBlock<PublishResponse>(pr => this.OnPublishResponse(pr));
+            this.stateMachineCts = new CancellationTokenSource();
+            this.publishResponses = new BroadcastBlock<PublishResponse>(null, new DataflowBlockOptions { CancellationToken = this.stateMachineCts.Token });
+        }
+
+
 
         /// <summary>
         /// Gets the asynchronous function that provides the user identity. Provide an <see cref="AnonymousIdentity"/>, <see cref="UserNameIdentity"/>, <see cref="IssuedIdentity"/> or <see cref="X509Identity"/>

--- a/UaClient/ServiceModel/Ua/UaApplicationOptions.cs
+++ b/UaClient/ServiceModel/Ua/UaApplicationOptions.cs
@@ -28,6 +28,18 @@ namespace Workstation.ServiceModel.Ua
     }
 
     /// <summary>
+    /// The UaTcpSessionChannel options.
+    /// </summary>
+   
+    public class UaTcpSessionChannelReconnectParameter
+    {
+        public byte[] RemoteNonce { get; set; } = null;
+        public NodeId AuthenticationToken { get; set; } = null;
+        public NodeId SessionId { get; set; } = null;
+    }
+
+
+    /// <summary>
     /// The UaTcpSecureChannel options.
     /// </summary>
     public class UaTcpSecureChannelOptions : UaTcpTransportChannelOptions


### PR DESCRIPTION
Created functionality to reconnect to an existing session in UaTcpSessionChannel.
The Parameters SessionId, RemoteNonce and AuthenticationToken are stored in UaTcpSessionChannelReconnectParameter which one can pass to UaTcpSessionChannel via the constructor. 