### PR TITLE
NRT: final step

### DIFF
--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2019 Converter Systems LLC
+Copyright (c) 2020 Converter Systems LLC
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -96,7 +96,6 @@ public class Program
 //   SoftwareVersion: 1.0.0-rc5-52-g04067153-dirty
 //   ManufacturerName: open62541
 //   State: Running
-//   CurrentTime: 09/08/2019 17:54:14
 
 ```
 

--- a/UaClient.UnitTests/IntegrationTests/IntegrationTests.cs
+++ b/UaClient.UnitTests/IntegrationTests/IntegrationTests.cs
@@ -44,11 +44,7 @@ namespace Workstation.UaClient.IntegrationTests
 
         public IntegrationTests()
         {
-            var serviceCollection = new ServiceCollection();
-            serviceCollection.AddLogging(builder => builder.AddDebug());
-
-            var serviceProvider = serviceCollection.BuildServiceProvider();
-            this.loggerFactory = serviceProvider.GetService<ILoggerFactory>();
+            this.loggerFactory = LoggerFactory.Create(builder => builder.AddDebug());
             this.logger = this.loggerFactory?.CreateLogger<IntegrationTests>();
 
             this.localDescription = new ApplicationDescription
@@ -318,7 +314,6 @@ namespace Workstation.UaClient.IntegrationTests
             logger.LogInformation($"SecurityMode: '{channel.RemoteEndpoint.SecurityMode}'.");
             logger.LogInformation($"Activated session '{channel.SessionId}'.");
 
-
             var readRequest = new ReadRequest { NodesToRead = new[] { new ReadValueId { NodeId = NodeId.Parse(VariableIds.Server_ServerStatus_CurrentTime), AttributeId = AttributeIds.Value } } };
             for (int i = 0; i < 10; i++)
             {
@@ -326,6 +321,7 @@ namespace Workstation.UaClient.IntegrationTests
                 logger.LogInformation("Read {0}", readResult.Results[0].GetValueOrDefault<DateTime>());
                 await Task.Delay(1000);
             }
+
             logger.LogInformation($"Closing session '{channel.SessionId}'.");
             await channel.CloseAsync();
         }

--- a/UaClient.UnitTests/LICENSE.txt
+++ b/UaClient.UnitTests/LICENSE.txt
@@ -1,6 +1,6 @@
 ﻿MIT License
 
-Copyright (c) 2019 Converter Systems LLC
+Copyright (c) 2020 Converter Systems LLC
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/UaClient.UnitTests/UnitTests/ArraySegmentExtensionTests.cs
+++ b/UaClient.UnitTests/UnitTests/ArraySegmentExtensionTests.cs
@@ -1,0 +1,174 @@
+﻿using FluentAssertions;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using Workstation.ServiceModel.Ua;
+using Xunit;
+
+namespace Workstation.UaClient.UnitTests
+{
+    public class ArraySegmentExtensionTests
+    {
+        [Fact]
+        public void AsArraySegment1()
+        {
+            var array = new int[] { 1, 2, 3, 4, 5 };
+
+            array.AsArraySegment()
+                .Should().BeEquivalentTo(array);
+        }
+        
+        [Fact]
+        public void AsArraySegmentWithOffset()
+        {
+            var array = new int[] { 1, 2, 3, 4, 5 };
+
+            array.AsArraySegment(1)
+                .Should().BeEquivalentTo(array.Skip(1));
+        }
+        
+        [Fact]
+        public void AsArraySegmentWithOffsetAndCount()
+        {
+            var array = new int[] { 1, 2, 3, 4, 5 };
+
+            array.AsArraySegment(1, 3)
+                .Should().BeEquivalentTo(array.Skip(1).Take(3));
+        }
+
+        [Fact]
+        public void CreateStream()
+        {
+            var array = new byte[] { 1, 2, 3, 4, 5, 6, 7, 8, 9, 10 };
+
+            using (var stream = ArraySegmentExtensions.CreateStream(array))
+            {
+                var buffer = new byte[array.Length];
+
+                stream.Length
+                    .Should().Be(array.Length);
+
+                stream.Read(buffer, 0, buffer.Length);
+
+                buffer
+                    .Should().BeEquivalentTo(array);
+            }
+        }
+        
+        [Fact]
+        public void CreateBinaryReader()
+        {
+            var array = new byte[] { 1, 2, 3, 4, 5, 6, 7, 8, 9, 10 };
+
+            using (var reader = ArraySegmentExtensions.CreateBinaryReader(array))
+            {
+                foreach (var b in array)
+                {
+                    reader.ReadByte()
+                        .Should().Be(b);
+                }
+            }
+        }
+        
+        [Fact]
+        public void CreateBinaryWriter()
+        {
+            var array = new byte[10];
+
+            using (var writer = ArraySegmentExtensions.CreateBinaryWriter(array))
+            {
+                for (byte b = 0; b < array.Length; b++)
+                {
+                    writer.Write(b);
+                }
+
+                array
+                    .Should().BeEquivalentTo(0, 1, 2, 3, 4, 5, 6, 7, 8, 9);
+            }
+        }
+
+        [Fact]
+        public void Take()
+        {
+            var array = new byte[] { 1, 2, 3, 4, 5, 6, 7, 8, 9, 10 };
+
+            array.AsArraySegment().Take(3)
+                .Should().BeEquivalentTo(array.Take(3));
+        }
+        
+        [Fact]
+        public void Skip()
+        {
+            var array = new byte[] { 1, 2, 3, 4, 5, 6, 7, 8, 9, 10 };
+
+            array.AsArraySegment().Skip(3)
+                .Should().BeEquivalentTo(array.Skip(3));
+        }
+
+        [Fact]
+        public void Slice()
+        {
+            var array = new byte[] { 1, 2, 3, 4, 5, 6, 7, 8, 9, 10 };
+
+            array.AsArraySegment().Slice(3, 4)
+                .Should().BeEquivalentTo(array.Skip(3).Take(4));
+        }
+
+        [Fact]
+        public void TakeLast()
+        {
+            var array = new byte[] { 1, 2, 3, 4, 5, 6, 7, 8, 9, 10 };
+
+            array.AsArraySegment().TakeLast(3)
+                .Should().BeEquivalentTo(array.TakeLast(3));
+        }
+        
+        [Fact]
+        public void SkipLast()
+        {
+            var array = new byte[] { 1, 2, 3, 4, 5, 6, 7, 8, 9, 10 };
+
+            array.AsArraySegment().SkipLast(3)
+                .Should().BeEquivalentTo(array.SkipLast(3));
+        }
+
+        [Fact]
+        public void CopyToArraySegment()
+        {
+            var array = new byte[] { 1, 2, 3, 4, 5, 6, 7, 8, 9, 10 };
+            var input = array.AsArraySegment(2, 5);
+            var output = new byte[10].AsArraySegment(4, 4);
+
+            ArraySegmentExtensions.CopyTo(input, output);
+
+            output
+                .Should().BeEquivalentTo(input.SkipLast(1));
+        }
+        
+        [Fact]
+        public void CopyToArray()
+        {
+            var array = new byte[] { 1, 2, 3, 4, 5, 6, 7, 8, 9, 10 };
+            var input = array.AsArraySegment(2, 5);
+            var output = new byte[10];
+
+            ArraySegmentExtensions.CopyTo(input, output);
+
+            output.Take(5)
+                .Should().BeEquivalentTo(input);
+        }
+        
+        [Fact]
+        public void ToArray()
+        {
+            var array = new byte[] { 1, 2, 3, 4, 5, 6, 7, 8, 9, 10 };
+            var input = array.AsArraySegment(2, 5);
+
+            var output = ArraySegmentExtensions.ToArray(input);
+
+            output
+                .Should().BeEquivalentTo(input);
+        }
+    }
+}

--- a/UaClient.UnitTests/UnitTests/DataTypeIdAttributeTests.cs
+++ b/UaClient.UnitTests/UnitTests/DataTypeIdAttributeTests.cs
@@ -1,0 +1,24 @@
+﻿using FluentAssertions;
+using System;
+using System.Collections.Generic;
+using System.Text;
+using Workstation.ServiceModel.Ua;
+using Xunit;
+
+namespace Workstation.UaClient.UnitTests
+{
+    public class DataTypeIdAttributeTests
+    {
+        public static IEnumerable<object[]> CreateData => ExpandedNodeIdTests.ParseData;
+
+        [MemberData(nameof(CreateData))]
+        [Theory]
+        public void Create(string s, ExpandedNodeId id)
+        {
+            var att = new DataTypeIdAttribute(s);
+
+            att.NodeId
+                .Should().Be(id);
+        }
+    }
+}

--- a/UaClient.UnitTests/UnitTests/IssuedIdentityTests.cs
+++ b/UaClient.UnitTests/UnitTests/IssuedIdentityTests.cs
@@ -1,0 +1,24 @@
+﻿using FluentAssertions;
+using System;
+using System.Collections.Generic;
+using System.Text;
+using Workstation.ServiceModel.Ua;
+using Xunit;
+
+namespace Workstation.UaClient.UnitTests
+{
+    public class IssuedIdentityTests
+    {
+        [InlineData(null)]
+        [InlineData(new byte[] { })]
+        [InlineData(new byte[] { 0x45, 0xff})]
+        [Theory]
+        public void Create(byte[] tokenData)
+        {
+            var id = new IssuedIdentity(tokenData);
+
+            id.TokenData
+                .Should().BeSameAs(tokenData);
+        }
+    }
+}

--- a/UaClient.UnitTests/UnitTests/MonitoredItemAttributeTests.cs
+++ b/UaClient.UnitTests/UnitTests/MonitoredItemAttributeTests.cs
@@ -1,0 +1,37 @@
+﻿using FluentAssertions;
+using System;
+using System.Collections.Generic;
+using System.Text;
+using Workstation.ServiceModel.Ua;
+using Xunit;
+
+namespace Workstation.UaClient.UnitTests
+{
+    public class MonitoredItemAttributeTests
+    {
+        [Fact]
+        public void Create()
+        {
+            var att = new MonitoredItemAttribute("s=Hello");
+
+            att.AttributeId
+                .Should().Be(AttributeIds.Value);
+            att.DataChangeTrigger
+                .Should().Be(DataChangeTrigger.StatusValue);
+            att.DeadbandType
+                .Should().Be(DeadbandType.None);
+            att.DeadbandValue
+                .Should().Be(0.0);
+            att.DiscardOldest
+                .Should().BeTrue();
+            att.IndexRange
+                .Should().BeNull();
+            att.NodeId
+                .Should().Be("s=Hello");
+            att.QueueSize
+                .Should().Be(0);
+            att.SamplingInterval
+                .Should().Be(-1);
+        }
+    }
+}

--- a/UaClient.UnitTests/UnitTests/ServiceExtensionsTests.cs
+++ b/UaClient.UnitTests/UnitTests/ServiceExtensionsTests.cs
@@ -1,0 +1,187 @@
+﻿using FluentAssertions;
+using System;
+using System.Collections.Generic;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using Workstation.ServiceModel.Ua;
+using Xunit;
+
+namespace Workstation.UaClient.UnitTests
+{
+    public class ServiceExtensionsTests
+    {
+        private static Task Never() => Task.Delay(-1);
+
+        private static async Task<T> Never<T>(T value)
+        {
+            await Never();
+            return value;
+        }
+
+        [Fact]
+        public void ToVariantArray()
+        {
+            var input = new object[] { 1, 2, 3, 70 };
+            var expected = new Variant[] { 1, 2, 3, 70 };
+
+            input.ToVariantArray()
+                .Should().BeEquivalentTo(expected);
+        }
+        
+        [Fact]
+        public void ToVariantArrayEmpty()
+        {
+            var input = new object[] { };
+            var expected = new Variant[] { };
+
+            input.ToVariantArray()
+                .Should().BeEquivalentTo(expected);
+        }
+        
+        [Fact]
+        public void ToVariantArrayNull()
+        {
+            var input = default(object[]);
+
+            input.Invoking(i => i.ToVariantArray())
+                .Should().Throw<ArgumentNullException>();
+        }
+        
+        [Fact]
+        public void ToObjectArray()
+        {
+            var input = new Variant[] { 1, 2, 3, 70 };
+            var expected = new object[] { 1, 2, 3, 70 };
+
+            input.ToObjectArray()
+                .Should().BeEquivalentTo(expected);
+        }
+        
+        [Fact]
+        public void ToObjectArrayEmpty()
+        {
+            var input = new Variant[] { };
+            var expected = new object[] { };
+
+            input.ToObjectArray()
+                .Should().BeEquivalentTo(expected);
+        }
+        
+        [Fact]
+        public void ToObjectArrayNull()
+        {
+            var input = default(Variant[]);
+
+            input.Invoking(i => i.ToObjectArray())
+                .Should().Throw<ArgumentNullException>();
+        }
+
+        [Fact]
+        public void WithCancellationCompleted()
+        {
+            var task = Task.CompletedTask;
+
+            task.WithCancellation(default).IsCompleted
+                .Should().BeTrue();
+        }
+        
+        [Fact]
+        public async Task WithCancellationFastTask()
+        {
+            using (var tcs = new CancellationTokenSource())
+            {
+                var fast = Task.Delay(1);
+                var task = fast.WithCancellation(tcs.Token);
+
+                await task.Invoking(t => t)
+                    .Should().NotThrowAsync();
+            }
+        }
+
+        [Fact]
+        public async Task WithCancellation()
+        {
+            using (var tcs = new CancellationTokenSource())
+            {
+                var never = Never();
+                var task = never.WithCancellation(tcs.Token);
+                tcs.Cancel();
+
+                await task.Invoking(t => t)
+                    .Should().ThrowAsync<OperationCanceledException>();
+            }
+        }
+        
+        [Fact]
+        public void ValueWithCancellationCompleted()
+        {
+            var task = Task.FromResult(10);
+
+            task.WithCancellation(default).IsCompleted
+                .Should().BeTrue();
+        }
+
+        [Fact]
+        public async Task ValueWithCancellation()
+        {
+            using (var tcs = new CancellationTokenSource())
+            {
+                var never = Never(10);
+                var task = never.WithCancellation(tcs.Token);
+                tcs.Cancel();
+
+                await task.Invoking(t => t)
+                    .Should().ThrowAsync<OperationCanceledException>();
+            }
+        }
+        
+        [Fact]
+        public void WithTimeoutAfterCompleted()
+        {
+            var task = Task.CompletedTask;
+
+            task.TimeoutAfter(-1).IsCompleted
+                .Should().BeTrue();
+        }
+        
+        [Fact]
+        public async Task WithTimeoutAfterFastTask()
+        {
+            var fast = Task.Delay(1);
+            var task = fast.TimeoutAfter(-1);
+
+            await task.Invoking(t => t)
+                .Should().NotThrowAsync();
+        }
+
+        [Fact]
+        public async Task WithTimeoutAfter()
+        {
+            var never = Never();
+            var task = never.TimeoutAfter(0);
+
+            await task.Invoking(t => t)
+                .Should().ThrowAsync<TimeoutException>();
+        }
+        
+        [Fact]
+        public void ValueWithTimeoutAfterCompleted()
+        {
+            var task = Task.FromResult(10);
+
+            task.TimeoutAfter(-1).IsCompleted
+                .Should().BeTrue();
+        }
+
+        [Fact]
+        public async Task ValueWithTimeoutAfter()
+        {
+            var never = Never(10);
+            var task = never.TimeoutAfter(0);
+
+            await task.Invoking(t => t)
+                .Should().ThrowAsync<TimeoutException>();
+        }
+    }
+}

--- a/UaClient.UnitTests/UnitTests/UaApplicationOptionsTests.cs
+++ b/UaClient.UnitTests/UnitTests/UaApplicationOptionsTests.cs
@@ -1,0 +1,50 @@
+﻿using FluentAssertions;
+using System;
+using System.Collections.Generic;
+using System.Text;
+using Workstation.ServiceModel.Ua;
+using Xunit;
+
+namespace Workstation.UaClient.UnitTests
+{
+    public class UaApplicationOptionsTests
+    {
+        [Fact]
+        public void UaTcpTransportChannelOptionsDefaults()
+        {
+            var lowestBufferSize = 8192u;
+
+            var options = new UaTcpTransportChannelOptions();
+
+            options.LocalReceiveBufferSize
+                .Should().BeGreaterOrEqualTo(lowestBufferSize);
+            options.LocalSendBufferSize
+                .Should().BeGreaterOrEqualTo(lowestBufferSize);
+        }
+
+        [Fact]
+        public void UaTcpSecureChannelOptionsDefaults()
+        {
+            var shortestTimespan = TimeSpan.FromMilliseconds(100);
+
+            var options = new UaTcpSecureChannelOptions();
+
+            TimeSpan.FromMilliseconds(options.TimeoutHint)
+                .Should().BeGreaterOrEqualTo(shortestTimespan);
+
+            options.DiagnosticsHint
+                .Should().Be(0);
+        }
+
+        [Fact]
+        public void UaTcpSessionChannelOptionsDefaults()
+        {
+            var shortestTimespan = TimeSpan.FromMilliseconds(100);
+
+            var options = new UaTcpSessionChannelOptions();
+
+            TimeSpan.FromMilliseconds(options.SessionTimeout)
+                .Should().BeGreaterOrEqualTo(shortestTimespan);
+        }
+    }
+}

--- a/UaClient.UnitTests/UnitTests/UserNameIdentityTests.cs
+++ b/UaClient.UnitTests/UnitTests/UserNameIdentityTests.cs
@@ -1,0 +1,27 @@
+﻿using FluentAssertions;
+using System;
+using System.Collections.Generic;
+using System.Text;
+using Workstation.ServiceModel.Ua;
+using Xunit;
+
+namespace Workstation.UaClient.UnitTests
+{
+    public class UserNameIdentityTests
+    {
+        [InlineData("", "")]
+        [InlineData("UserName", "Password")]
+        [InlineData(null, "Password")]
+        [InlineData("UserName", null)]
+        [Theory]
+        public void Create(string userName, string password)
+        {
+            var user = new UserNameIdentity(userName, password);
+
+            user.UserName
+                .Should().Be(userName);
+            user.Password
+                .Should().Be(password);
+        }
+    }
+}

--- a/UaClient.UnitTests/UnitTests/X509IdentityTests.cs
+++ b/UaClient.UnitTests/UnitTests/X509IdentityTests.cs
@@ -1,0 +1,27 @@
+﻿using FluentAssertions;
+using Org.BouncyCastle.Asn1.X509;
+using Org.BouncyCastle.Crypto.Parameters;
+using Org.BouncyCastle.Math;
+using Org.BouncyCastle.X509;
+using System;
+using System.Collections.Generic;
+using System.Text;
+using Workstation.ServiceModel.Ua;
+using Xunit;
+
+namespace Workstation.UaClient.UnitTests
+{
+    public class X509IdentityTests
+    {
+        [Fact]
+        public void CreateNull()
+        {
+            var id = new X509Identity(null, null);
+
+            id.Certificate
+                .Should().BeNull();
+            id.PrivateKey
+                .Should().BeNull();
+        }
+    }
+}

--- a/UaClient.UnitTests/UnitTests/XmlEncodingIdAttributeTests.cs
+++ b/UaClient.UnitTests/UnitTests/XmlEncodingIdAttributeTests.cs
@@ -1,0 +1,24 @@
+﻿using FluentAssertions;
+using System;
+using System.Collections.Generic;
+using System.Text;
+using Workstation.ServiceModel.Ua;
+using Xunit;
+
+namespace Workstation.UaClient.UnitTests
+{
+    public class XmlEncodingIdAttributeTests
+    {
+        public static IEnumerable<object[]> CreateData => ExpandedNodeIdTests.ParseData;
+
+        [MemberData(nameof(CreateData))]
+        [Theory]
+        public void Create(string s, ExpandedNodeId id)
+        {
+            var att = new XmlEncodingIdAttribute(s);
+
+            att.NodeId
+                .Should().Be(id);
+        }
+    }
+}

--- a/UaClient/Collections/ErrorsContainer.cs
+++ b/UaClient/Collections/ErrorsContainer.cs
@@ -5,8 +5,6 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 
-#nullable enable
-
 namespace Workstation.Collections
 {
     /// <summary>

--- a/UaClient/Collections/ObservableQueue.cs
+++ b/UaClient/Collections/ObservableQueue.cs
@@ -5,8 +5,6 @@ using System.Collections.Generic;
 using System.Collections.Specialized;
 using System.ComponentModel;
 
-#nullable enable
-
 namespace Workstation.Collections
 {
     /// <summary>

--- a/UaClient/Internal/System.Diagnostics.CodeAnalysis.cs
+++ b/UaClient/Internal/System.Diagnostics.CodeAnalysis.cs
@@ -26,7 +26,7 @@ namespace System.Diagnostics.CodeAnalysis
     internal sealed partial class DoesNotReturnIfAttribute : System.Attribute
     {
         public DoesNotReturnIfAttribute(bool parameterValue) { }
-        public bool ParameterValue { get { throw null; } }
+        public bool ParameterValue { get { throw null!; } }
     }
     [System.AttributeUsageAttribute(System.AttributeTargets.Field | System.AttributeTargets.Parameter | System.AttributeTargets.Property | System.AttributeTargets.ReturnValue, Inherited = false)]
     internal sealed partial class MaybeNullAttribute : System.Attribute
@@ -37,7 +37,7 @@ namespace System.Diagnostics.CodeAnalysis
     internal sealed partial class MaybeNullWhenAttribute : System.Attribute
     {
         public MaybeNullWhenAttribute(bool returnValue) { }
-        public bool ReturnValue { get { throw null; } }
+        public bool ReturnValue { get { throw null!; } }
     }
     [System.AttributeUsageAttribute(System.AttributeTargets.Field | System.AttributeTargets.Parameter | System.AttributeTargets.Property | System.AttributeTargets.ReturnValue, Inherited = false)]
     internal sealed partial class NotNullAttribute : System.Attribute
@@ -48,13 +48,13 @@ namespace System.Diagnostics.CodeAnalysis
     internal sealed partial class NotNullIfNotNullAttribute : System.Attribute
     {
         public NotNullIfNotNullAttribute(string parameterName) { }
-        public string ParameterName { get { throw null; } }
+        public string ParameterName { get { throw null!; } }
     }
     [System.AttributeUsageAttribute(System.AttributeTargets.Parameter, Inherited = false)]
     internal sealed partial class NotNullWhenAttribute : System.Attribute
     {
         public NotNullWhenAttribute(bool returnValue) { }
-        public bool ReturnValue { get { throw null; } }
+        public bool ReturnValue { get { throw null!; } }
     }
 }
 

--- a/UaClient/ServiceModel/Ua/AccessLevelFlags.cs
+++ b/UaClient/ServiceModel/Ua/AccessLevelFlags.cs
@@ -3,8 +3,6 @@
 
 using System;
 
-#nullable enable
-
 namespace Workstation.ServiceModel.Ua
 {
     [Flags]

--- a/UaClient/ServiceModel/Ua/AcknowledgeableCondition.cs
+++ b/UaClient/ServiceModel/Ua/AcknowledgeableCondition.cs
@@ -4,8 +4,6 @@
 using System;
 using System.Collections.Generic;
 
-#nullable enable
-
 namespace Workstation.ServiceModel.Ua
 {
     /// <summary>

--- a/UaClient/ServiceModel/Ua/AlarmCondition.cs
+++ b/UaClient/ServiceModel/Ua/AlarmCondition.cs
@@ -4,8 +4,6 @@
 using System;
 using System.Collections.Generic;
 
-#nullable enable
-
 namespace Workstation.ServiceModel.Ua
 {
     /// <summary>

--- a/UaClient/ServiceModel/Ua/AnonymousIdentity.cs
+++ b/UaClient/ServiceModel/Ua/AnonymousIdentity.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright (c) Converter Systems LLC. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-#nullable enable
-
 namespace Workstation.ServiceModel.Ua
 {
     public class AnonymousIdentity : IUserIdentity

--- a/UaClient/ServiceModel/Ua/ArraySegmentExtensions.cs
+++ b/UaClient/ServiceModel/Ua/ArraySegmentExtensions.cs
@@ -4,8 +4,6 @@
 using System;
 using System.IO;
 
-#nullable enable
-
 namespace Workstation.ServiceModel.Ua
 {
     /// <summary>

--- a/UaClient/ServiceModel/Ua/AttributeServiceSet.cs
+++ b/UaClient/ServiceModel/Ua/AttributeServiceSet.cs
@@ -5,8 +5,6 @@ using System;
 using System.Threading;
 using System.Threading.Tasks;
 
-#nullable enable
-
 namespace Workstation.ServiceModel.Ua
 {
     public static class AttributeServiceSet

--- a/UaClient/ServiceModel/Ua/AttributeServiceSet.cs
+++ b/UaClient/ServiceModel/Ua/AttributeServiceSet.cs
@@ -2,8 +2,8 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
+using System.Threading;
 using System.Threading.Tasks;
-using Workstation.ServiceModel.Ua.Channels;
 
 #nullable enable
 
@@ -17,14 +17,14 @@ namespace Workstation.ServiceModel.Ua
         /// <param name="client">A instance of <see cref="IRequestChannel"/>.</param>
         /// <param name="request">A <see cref="ReadRequest"/>.</param>
         /// <returns>A <see cref="Task"/> representing the asynchronous operation that returns a <see cref="ReadResponse"/>.</returns>
-        public static async Task<ReadResponse> ReadAsync(this IRequestChannel client, ReadRequest request)
+        public static async Task<ReadResponse> ReadAsync(this IRequestChannel client, ReadRequest request, CancellationToken token = default)
         {
             if (request == null)
             {
                 throw new ArgumentNullException(nameof(request));
             }
 
-            return (ReadResponse)await client.RequestAsync(request).ConfigureAwait(false);
+            return (ReadResponse)await client.RequestAsync(request, token).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -33,14 +33,14 @@ namespace Workstation.ServiceModel.Ua
         /// <param name="client">A instance of <see cref="IRequestChannel"/>.</param>
         /// <param name="request">A <see cref="WriteRequest"/>.</param>
         /// <returns>A <see cref="Task"/> representing the asynchronous operation that returns a <see cref="WriteResponse"/>.</returns>
-        public static async Task<WriteResponse> WriteAsync(this IRequestChannel client, WriteRequest request)
+        public static async Task<WriteResponse> WriteAsync(this IRequestChannel client, WriteRequest request, CancellationToken token = default)
         {
             if (request == null)
             {
                 throw new ArgumentNullException(nameof(request));
             }
 
-            return (WriteResponse)await client.RequestAsync(request).ConfigureAwait(false);
+            return (WriteResponse)await client.RequestAsync(request, token).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -49,14 +49,14 @@ namespace Workstation.ServiceModel.Ua
         /// <param name="client">A instance of <see cref="IRequestChannel"/>.</param>
         /// <param name="request">A <see cref="HistoryReadRequest"/>.</param>
         /// <returns>A <see cref="Task"/> representing the asynchronous operation that returns a <see cref="HistoryReadResponse"/>.</returns>
-        public static async Task<HistoryReadResponse> HistoryReadAsync(this IRequestChannel client, HistoryReadRequest request)
+        public static async Task<HistoryReadResponse> HistoryReadAsync(this IRequestChannel client, HistoryReadRequest request, CancellationToken token = default)
         {
             if (request == null)
             {
                 throw new ArgumentNullException(nameof(request));
             }
 
-            return (HistoryReadResponse)await client.RequestAsync(request).ConfigureAwait(false);
+            return (HistoryReadResponse)await client.RequestAsync(request, token).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -65,14 +65,14 @@ namespace Workstation.ServiceModel.Ua
         /// <param name="client">A instance of <see cref="IRequestChannel"/>.</param>
         /// <param name="request">A <see cref="HistoryUpdateRequest"/>.</param>
         /// <returns>A <see cref="Task"/> representing the asynchronous operation that returns a <see cref="HistoryUpdateResponse"/>.</returns>
-        public static async Task<HistoryUpdateResponse> HistoryUpdateAsync(this IRequestChannel client, HistoryUpdateRequest request)
+        public static async Task<HistoryUpdateResponse> HistoryUpdateAsync(this IRequestChannel client, HistoryUpdateRequest request, CancellationToken token = default)
         {
             if (request == null)
             {
                 throw new ArgumentNullException(nameof(request));
             }
 
-            return (HistoryUpdateResponse)await client.RequestAsync(request).ConfigureAwait(false);
+            return (HistoryUpdateResponse)await client.RequestAsync(request, token).ConfigureAwait(false);
         }
     }
 }

--- a/UaClient/ServiceModel/Ua/BaseEvent.cs
+++ b/UaClient/ServiceModel/Ua/BaseEvent.cs
@@ -4,8 +4,6 @@
 using System;
 using System.Collections.Generic;
 
-#nullable enable
-
 namespace Workstation.ServiceModel.Ua
 {
     /// <summary>

--- a/UaClient/ServiceModel/Ua/BinaryEncodingIdAttribute.cs
+++ b/UaClient/ServiceModel/Ua/BinaryEncodingIdAttribute.cs
@@ -3,8 +3,6 @@
 
 using System;
 
-#nullable enable
-
 namespace Workstation.ServiceModel.Ua
 {
     /// <summary>

--- a/UaClient/ServiceModel/Ua/Channels/BinaryDecoder.cs
+++ b/UaClient/ServiceModel/Ua/Channels/BinaryDecoder.cs
@@ -30,7 +30,7 @@ namespace Workstation.ServiceModel.Ua.Channels
 
             this.stream = stream;
             this.channel = channel;
-            this.encoding = new UTF8Encoding(false, true);
+            this.encoding = new UTF8Encoding(false, false);
             this.reader = new BinaryReader(this.stream, this.encoding, keepStreamOpen);
         }
 

--- a/UaClient/ServiceModel/Ua/Channels/BinaryDecoder.cs
+++ b/UaClient/ServiceModel/Ua/Channels/BinaryDecoder.cs
@@ -8,8 +8,6 @@ using System.Text;
 using System.Xml;
 using System.Xml.Linq;
 
-#nullable enable
-
 namespace Workstation.ServiceModel.Ua.Channels
 {
     public sealed class BinaryDecoder : IDecoder, IDisposable

--- a/UaClient/ServiceModel/Ua/Channels/BinaryEncoder.cs
+++ b/UaClient/ServiceModel/Ua/Channels/BinaryEncoder.cs
@@ -31,7 +31,7 @@ namespace Workstation.ServiceModel.Ua.Channels
 
             this.stream = stream;
             this.channel = channel;
-            this.encoding = new UTF8Encoding(false, true);
+            this.encoding = new UTF8Encoding(false, false);
             this.writer = new BinaryWriter(this.stream, this.encoding, keepStreamOpen);
         }
 

--- a/UaClient/ServiceModel/Ua/Channels/BinaryEncoder.cs
+++ b/UaClient/ServiceModel/Ua/Channels/BinaryEncoder.cs
@@ -10,8 +10,6 @@ using System.Reflection;
 using System.Text;
 using System.Xml.Linq;
 
-#nullable enable
-
 namespace Workstation.ServiceModel.Ua.Channels
 {
     public sealed class BinaryEncoder : IEncoder, IDisposable

--- a/UaClient/ServiceModel/Ua/Channels/CommunicationObject.cs
+++ b/UaClient/ServiceModel/Ua/Channels/CommunicationObject.cs
@@ -7,8 +7,6 @@ using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
 
-#nullable enable
-
 namespace Workstation.ServiceModel.Ua.Channels
 {
     /// <summary>

--- a/UaClient/ServiceModel/Ua/Channels/CommunicationObject.cs
+++ b/UaClient/ServiceModel/Ua/Channels/CommunicationObject.cs
@@ -60,7 +60,7 @@ namespace Workstation.ServiceModel.Ua.Channels
         /// </summary>
         /// <param name="token">The <see cref="T:System.Threading.CancellationToken" /> that notifies when the task should be canceled.</param>
         /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
-        public async Task AbortAsync(CancellationToken token = default(CancellationToken))
+        public async Task AbortAsync(CancellationToken token = default)
         {
             await this.semaphore.WaitAsync(token).ConfigureAwait(false);
             try
@@ -109,7 +109,7 @@ namespace Workstation.ServiceModel.Ua.Channels
         /// </summary>
         /// <param name="token">The <see cref="T:System.Threading.CancellationToken" /> that notifies when the task should be canceled.</param>
         /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
-        public async Task CloseAsync(CancellationToken token = default(CancellationToken))
+        public async Task CloseAsync(CancellationToken token = default)
         {
             CommunicationState communicationState;
             await this.semaphore.WaitAsync(token).ConfigureAwait(false);
@@ -181,7 +181,7 @@ namespace Workstation.ServiceModel.Ua.Channels
         /// </summary>
         /// <param name="token">The <see cref="T:System.Threading.CancellationToken" /> that notifies when the task should be canceled.</param>
         /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
-        public async Task OpenAsync(CancellationToken token = default(CancellationToken))
+        public async Task OpenAsync(CancellationToken token = default)
         {
             await this.semaphore.WaitAsync(token).ConfigureAwait(false);
             try
@@ -226,7 +226,7 @@ namespace Workstation.ServiceModel.Ua.Channels
         /// </summary>
         /// <param name="token">The <see cref="T:System.Threading.CancellationToken" /> that notifies when the task should be canceled.</param>
         /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
-        protected async Task FaultAsync(CancellationToken token = default(CancellationToken))
+        protected async Task FaultAsync(CancellationToken token = default)
         {
             await this.semaphore.WaitAsync(token).ConfigureAwait(false);
             try
@@ -257,7 +257,7 @@ namespace Workstation.ServiceModel.Ua.Channels
         /// <param name="exception">The exception.</param>
         /// <param name="token">The <see cref="T:System.Threading.CancellationToken" /> that notifies when the task should be canceled.</param>
         /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
-        protected async Task FaultAsync(Exception exception, CancellationToken token = default(CancellationToken))
+        protected async Task FaultAsync(Exception exception, CancellationToken token = default)
         {
             this.AddPendingException(exception);
             await this.FaultAsync(token).ConfigureAwait(false);
@@ -268,21 +268,21 @@ namespace Workstation.ServiceModel.Ua.Channels
         /// </summary>
         /// <param name="token">The <see cref="T:System.Threading.CancellationToken" /> that notifies when the task should be canceled.</param>
         /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
-        protected abstract Task OnAbortAsync(CancellationToken token = default(CancellationToken));
+        protected abstract Task OnAbortAsync(CancellationToken token = default);
 
         /// <summary>
         /// Inserts processing on a communication object after it transitions to the closing state due to the invocation of the CloseAsync operation.
         /// </summary>
         /// <param name="token">The <see cref="T:System.Threading.CancellationToken" /> that notifies when the task should be canceled.</param>
         /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
-        protected abstract Task OnCloseAsync(CancellationToken token = default(CancellationToken));
+        protected abstract Task OnCloseAsync(CancellationToken token = default);
 
         /// <summary>
         /// Invoked during the transition of a communication object into the closed state.
         /// </summary>
         /// <param name="token">The <see cref="T:System.Threading.CancellationToken" /> that notifies when the task should be canceled.</param>
         /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
-        protected virtual async Task OnClosedAsync(CancellationToken token = default(CancellationToken))
+        protected virtual async Task OnClosedAsync(CancellationToken token = default)
         {
             this.onClosedCalled = true;
             await this.semaphore.WaitAsync(token).ConfigureAwait(false);
@@ -314,7 +314,7 @@ namespace Workstation.ServiceModel.Ua.Channels
         /// </summary>
         /// <param name="token">The <see cref="T:System.Threading.CancellationToken" /> that notifies when the task should be canceled.</param>
         /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
-        protected virtual async Task OnClosingAsync(CancellationToken token = default(CancellationToken))
+        protected virtual async Task OnClosingAsync(CancellationToken token = default)
         {
             this.onClosingCalled = true;
             await this.semaphore.WaitAsync(token).ConfigureAwait(false);
@@ -345,7 +345,7 @@ namespace Workstation.ServiceModel.Ua.Channels
         /// </summary>
         /// <param name="token">The <see cref="T:System.Threading.CancellationToken" /> that notifies when the task should be canceled.</param>
         /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
-        protected virtual async Task OnFaulted(CancellationToken token = default(CancellationToken))
+        protected virtual async Task OnFaulted(CancellationToken token = default)
         {
             await this.semaphore.WaitAsync(token).ConfigureAwait(false);
             try
@@ -375,14 +375,14 @@ namespace Workstation.ServiceModel.Ua.Channels
         /// </summary>
         /// <param name="token">The <see cref="T:System.Threading.CancellationToken" /> that notifies when the task should be canceled.</param>
         /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
-        protected abstract Task OnOpenAsync(CancellationToken token = default(CancellationToken));
+        protected abstract Task OnOpenAsync(CancellationToken token = default);
 
         /// <summary>
         /// Invoked during the transition of a communication object into the opened state.
         /// </summary>
         /// <param name="token">The <see cref="T:System.Threading.CancellationToken" /> that notifies when the task should be canceled.</param>
         /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
-        protected virtual async Task OnOpenedAsync(CancellationToken token = default(CancellationToken))
+        protected virtual async Task OnOpenedAsync(CancellationToken token = default)
         {
             this.onOpenedCalled = true;
             await this.semaphore.WaitAsync(token).ConfigureAwait(false);
@@ -413,7 +413,7 @@ namespace Workstation.ServiceModel.Ua.Channels
         /// </summary>
         /// <param name="token">The <see cref="T:System.Threading.CancellationToken" /> that notifies when the task should be canceled.</param>
         /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
-        protected virtual async Task OnOpeningAsync(CancellationToken token = default(CancellationToken))
+        protected virtual async Task OnOpeningAsync(CancellationToken token = default)
         {
             this.onOpeningCalled = true;
             await this.semaphore.WaitAsync(token).ConfigureAwait(false);

--- a/UaClient/ServiceModel/Ua/Channels/ServiceOperation.cs
+++ b/UaClient/ServiceModel/Ua/Channels/ServiceOperation.cs
@@ -3,8 +3,6 @@
 
 using System.Threading.Tasks;
 
-#nullable enable
-
 namespace Workstation.ServiceModel.Ua.Channels
 {
     public class ServiceOperation : TaskCompletionSource<IServiceResponse>

--- a/UaClient/ServiceModel/Ua/Channels/UaTcpMessageTypes.cs
+++ b/UaClient/ServiceModel/Ua/Channels/UaTcpMessageTypes.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright (c) Converter Systems LLC. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-#nullable enable
-
 namespace Workstation.ServiceModel.Ua
 {
     public static class UaTcpMessageTypes

--- a/UaClient/ServiceModel/Ua/Channels/UaTcpSecureChannel.cs
+++ b/UaClient/ServiceModel/Ua/Channels/UaTcpSecureChannel.cs
@@ -281,14 +281,14 @@ namespace Workstation.ServiceModel.Ua.Channels
         /// </summary>
         /// <param name="request">The request.</param>
         /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
-        public virtual async Task<IServiceResponse> RequestAsync(IServiceRequest request)
+        public virtual async Task<IServiceResponse> RequestAsync(IServiceRequest request, CancellationToken token = default)
         {
             this.ThrowIfClosedOrNotOpening();
             this.TimestampHeader(request);
             var operation = new ServiceOperation(request);
             // TimestampHeader takes care that the RequestHeader property will not be null
             using (var timeoutCts = new CancellationTokenSource((int)request.RequestHeader!.TimeoutHint))
-            using (var linkedCts = CancellationTokenSource.CreateLinkedTokenSource(timeoutCts.Token, this.channelCts.Token))
+            using (var linkedCts = CancellationTokenSource.CreateLinkedTokenSource(timeoutCts.Token, this.channelCts.Token, token))
             using (var registration = linkedCts.Token.Register(o => ((ServiceOperation)o!).TrySetException(new ServiceResultException(StatusCodes.BadRequestTimeout)), operation, false))
             {
                 if (this.pendingRequests.Post(operation))
@@ -673,7 +673,7 @@ namespace Workstation.ServiceModel.Ua.Channels
         }
 
         /// <inheritdoc/>
-        protected override async Task OnOpenAsync(CancellationToken token = default(CancellationToken))
+        protected override async Task OnOpenAsync(CancellationToken token = default)
         {
             await base.OnOpenAsync(token).ConfigureAwait(false);
 
@@ -702,7 +702,7 @@ namespace Workstation.ServiceModel.Ua.Channels
         }
 
         /// <inheritdoc/>
-        protected override async Task OnOpenedAsync(CancellationToken token = default(CancellationToken))
+        protected override async Task OnOpenedAsync(CancellationToken token = default)
         {
             await base.OnOpenedAsync(token);
 
@@ -726,7 +726,7 @@ namespace Workstation.ServiceModel.Ua.Channels
         }
 
         /// <inheritdoc/>
-        protected override async Task OnCloseAsync(CancellationToken token = default(CancellationToken))
+        protected override async Task OnCloseAsync(CancellationToken token = default)
         {
             try
             {
@@ -742,7 +742,7 @@ namespace Workstation.ServiceModel.Ua.Channels
         }
 
         /// <inheritdoc/>
-        protected override async Task OnAbortAsync(CancellationToken token = default(CancellationToken))
+        protected override async Task OnAbortAsync(CancellationToken token = default)
         {
             await base.OnAbortAsync(token).ConfigureAwait(false);
         }
@@ -825,7 +825,7 @@ namespace Workstation.ServiceModel.Ua.Channels
         /// <param name="operation">A service operation.</param>
         /// <param name="token">A cancellation token</param>
         /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
-        private async Task SendRequestAsync(ServiceOperation operation, CancellationToken token = default(CancellationToken))
+        private async Task SendRequestAsync(ServiceOperation operation, CancellationToken token = default)
         {
             await this.sendingSemaphore.WaitAsync(token).ConfigureAwait(false);
             var request = operation.Request;
@@ -1413,7 +1413,7 @@ namespace Workstation.ServiceModel.Ua.Channels
         /// </summary>
         /// <param name="token">A cancellation token</param>
         /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
-        private async Task ReceiveResponsesAsync(CancellationToken token = default(CancellationToken))
+        private async Task ReceiveResponsesAsync(CancellationToken token = default)
         {
             try
             {
@@ -1489,7 +1489,7 @@ namespace Workstation.ServiceModel.Ua.Channels
         /// </summary>
         /// <param name="token">A cancellation token</param>
         /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
-        private async Task<IServiceResponse?> ReceiveResponseAsync(CancellationToken token = default(CancellationToken))
+        private async Task<IServiceResponse?> ReceiveResponseAsync(CancellationToken token = default)
         {
             await this.receivingSemaphore.WaitAsync(token).ConfigureAwait(false);
             try

--- a/UaClient/ServiceModel/Ua/Channels/UaTcpSecureChannel.cs
+++ b/UaClient/ServiceModel/Ua/Channels/UaTcpSecureChannel.cs
@@ -35,8 +35,6 @@ using Org.BouncyCastle.Utilities.Encoders;
 using Org.BouncyCastle.X509;
 using Org.BouncyCastle.X509.Extension;
 
-#nullable enable
-
 namespace Workstation.ServiceModel.Ua.Channels
 {
     /// <summary>

--- a/UaClient/ServiceModel/Ua/Channels/UaTcpSessionChannel.cs
+++ b/UaClient/ServiceModel/Ua/Channels/UaTcpSessionChannel.cs
@@ -12,8 +12,6 @@ using Org.BouncyCastle.Crypto;
 using Org.BouncyCastle.Security;
 using System.Collections.Generic;
 
-#nullable enable
-
 namespace Workstation.ServiceModel.Ua.Channels
 {
     /// <summary>

--- a/UaClient/ServiceModel/Ua/Channels/UaTcpSessionChannel.cs
+++ b/UaClient/ServiceModel/Ua/Channels/UaTcpSessionChannel.cs
@@ -27,14 +27,19 @@ namespace Workstation.ServiceModel.Ua.Channels
         public const double DefaultSessionTimeout = 120 * 1000; // 2 minutes
 
         /// <summary>
-        /// The default publishing interval.
+        /// The default subscription publishing interval.
         /// </summary>
         public const double DefaultPublishingInterval = 1000f;
 
         /// <summary>
-        /// The default keep alive count.
+        /// The default subscription keep-alive count.
         /// </summary>
         public const uint DefaultKeepaliveCount = 30;
+
+        /// <summary>
+        /// The default subscription lifetime count.
+        /// </summary>
+        public const uint DefaultLifetimeCount = DefaultKeepaliveCount* 3;
 
         private const string RsaSha1Signature = @"http://www.w3.org/2000/09/xmldsig#rsa-sha1";
         private const string RsaSha256Signature = @"http://www.w3.org/2001/04/xmldsig-more#rsa-sha256";
@@ -241,7 +246,7 @@ namespace Workstation.ServiceModel.Ua.Channels
         }
 
         /// <inheritdoc/>
-        protected override async Task OnOpeningAsync(CancellationToken token = default(CancellationToken))
+        protected override async Task OnOpeningAsync(CancellationToken token = default)
         {
             if (this.RemoteEndpoint.Server == null)
             {
@@ -301,7 +306,7 @@ namespace Workstation.ServiceModel.Ua.Channels
         }
 
         /// <inheritdoc/>
-        protected override async Task OnOpenAsync(CancellationToken token = default(CancellationToken))
+        protected override async Task OnOpenAsync(CancellationToken token = default)
         {
             this.logger?.LogInformation($"Opening session channel with endpoint '{this.RemoteEndpoint.EndpointUrl}'.");
             this.logger?.LogInformation($"SecurityPolicy: '{this.RemoteEndpoint.SecurityPolicyUri}'.");
@@ -316,8 +321,8 @@ namespace Workstation.ServiceModel.Ua.Channels
             // requires from previous Session: SessionId, AuthenticationToken, RemoteNonce
             if (this.SessionId == null)
             {
-                var localNonce = this.RemoteEndpoint.SecurityMode != MessageSecurityMode.None ? this.GetNextNonce(NonceLength) : null;
-                var localCertificate = this.RemoteEndpoint.SecurityMode != MessageSecurityMode.None ? this.LocalCertificate : null;
+                var localNonce = this.GetNextNonce(NonceLength);
+                var localCertificate = this.LocalCertificate;
                 var createSessionRequest = new CreateSessionRequest
                 {
                     ClientDescription = this.LocalDescription,
@@ -736,9 +741,9 @@ namespace Workstation.ServiceModel.Ua.Channels
             // create the keep alive subscription.
             var subscriptionRequest = new CreateSubscriptionRequest
             {
-                RequestedPublishingInterval = DefaultPublishingInterval,
-                RequestedMaxKeepAliveCount = DefaultKeepaliveCount,
-                RequestedLifetimeCount = DefaultKeepaliveCount * 3,
+                RequestedPublishingInterval = 1000f,
+                RequestedMaxKeepAliveCount = 5,
+                RequestedLifetimeCount = 120,
                 PublishingEnabled = true,
             };
             var subscriptionResponse = await this.CreateSubscriptionAsync(subscriptionRequest).ConfigureAwait(false);
@@ -752,14 +757,14 @@ namespace Workstation.ServiceModel.Ua.Channels
         }
 
         /// <inheritdoc/>
-        protected override Task OnClosingAsync(CancellationToken token = default(CancellationToken))
+        protected override Task OnClosingAsync(CancellationToken token = default)
         {
             this.stateMachineCts.Cancel();
             return base.OnClosingAsync(token);
         }
 
         /// <inheritdoc/>
-        protected override async Task OnCloseAsync(CancellationToken token = default(CancellationToken))
+        protected override async Task OnCloseAsync(CancellationToken token = default)
         {
             await this.CloseSessionAsync(new CloseSessionRequest { DeleteSubscriptions = true }).ConfigureAwait(false);
             await Task.Delay(1000).ConfigureAwait(false);
@@ -780,7 +785,7 @@ namespace Workstation.ServiceModel.Ua.Channels
         /// </summary>
         /// <param name="token">A cancellation token.</param>
         /// <returns>A task.</returns>
-        private async Task PublishAsync(CancellationToken token = default(CancellationToken))
+        private async Task PublishAsync(CancellationToken token = default)
         {
             var publishRequest = new PublishRequest
             {
@@ -791,7 +796,7 @@ namespace Workstation.ServiceModel.Ua.Channels
             {
                 try
                 {
-                    var publishResponse = await this.PublishAsync(publishRequest).WithCancellation(token).ConfigureAwait(false);
+                    var publishResponse = await this.PublishAsync(publishRequest, token).ConfigureAwait(false);
 
                     // post to linked data flow blocks and subscriptions.
                     this.publishResponses.Post(publishResponse);
@@ -834,7 +839,7 @@ namespace Workstation.ServiceModel.Ua.Channels
         /// </summary>
         /// <param name="token">A cancellation token.</param>
         /// <returns>A task.</returns>
-        private async Task StateMachineAsync(CancellationToken token = default(CancellationToken))
+        private async Task StateMachineAsync(CancellationToken token = default)
         {
             var tasks = new[]
             {

--- a/UaClient/ServiceModel/Ua/Channels/UaTcpTransportChannel.cs
+++ b/UaClient/ServiceModel/Ua/Channels/UaTcpTransportChannel.cs
@@ -109,7 +109,7 @@ namespace Workstation.ServiceModel.Ua.Channels
         /// <param name="count">The count.</param>
         /// <param name="token">A cancellation token.</param>
         /// <returns>A task.</returns>
-        protected virtual async Task SendAsync(byte[] buffer, int offset, int count, CancellationToken token = default(CancellationToken))
+        protected virtual async Task SendAsync(byte[] buffer, int offset, int count, CancellationToken token = default)
         {
             this.ThrowIfClosedOrNotOpening();
             var stream = this.stream ?? throw new InvalidOperationException("The stream field is null!");
@@ -124,7 +124,7 @@ namespace Workstation.ServiceModel.Ua.Channels
         /// <param name="count">The count.</param>
         /// <param name="token">A cancellation token.</param>
         /// <returns>A task.</returns>
-        protected virtual async Task<int> ReceiveAsync(byte[] buffer, int offset, int count, CancellationToken token = default(CancellationToken))
+        protected virtual async Task<int> ReceiveAsync(byte[] buffer, int offset, int count, CancellationToken token = default)
         {
             this.ThrowIfClosedOrNotOpening();
             var stream = this.stream ?? throw new InvalidOperationException("The stream field is null!");
@@ -191,7 +191,7 @@ namespace Workstation.ServiceModel.Ua.Channels
 
             this.tcpClient = new TcpClient { NoDelay = true };
             var uri = new UriBuilder(this.RemoteEndpoint.EndpointUrl!);
-            await this.tcpClient.ConnectAsync(uri.Host, uri.Port).WithTimeoutAfter(ConnectTimeout).ConfigureAwait(false);
+            await this.tcpClient.ConnectAsync(uri.Host, uri.Port).TimeoutAfter(ConnectTimeout).ConfigureAwait(false);
             this.stream = this.tcpClient.GetStream();
 
             // send 'hello'.

--- a/UaClient/ServiceModel/Ua/Channels/UaTcpTransportChannel.cs
+++ b/UaClient/ServiceModel/Ua/Channels/UaTcpTransportChannel.cs
@@ -8,8 +8,6 @@ using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
 
-#nullable enable
-
 namespace Workstation.ServiceModel.Ua.Channels
 {
     /// <summary>

--- a/UaClient/ServiceModel/Ua/CommunicationsState.cs
+++ b/UaClient/ServiceModel/Ua/CommunicationsState.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright (c) Converter Systems LLC. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-#nullable enable
-
 namespace Workstation.ServiceModel.Ua
 {
     /// <summary>Defines the states in which an <see cref="T:ConverterSystems.ServiceModel.Ua.ICommunicationObject" /> can exist. </summary>

--- a/UaClient/ServiceModel/Ua/Condition.cs
+++ b/UaClient/ServiceModel/Ua/Condition.cs
@@ -4,8 +4,6 @@
 using System;
 using System.Collections.Generic;
 
-#nullable enable
-
 namespace Workstation.ServiceModel.Ua
 {
     /// <summary>

--- a/UaClient/ServiceModel/Ua/DataTypeIdAttribute.cs
+++ b/UaClient/ServiceModel/Ua/DataTypeIdAttribute.cs
@@ -3,8 +3,6 @@
 
 using System;
 
-#nullable enable
-
 namespace Workstation.ServiceModel.Ua
 {
     /// <summary>

--- a/UaClient/ServiceModel/Ua/DataValue.cs
+++ b/UaClient/ServiceModel/Ua/DataValue.cs
@@ -3,8 +3,6 @@
 
 using System;
 
-#nullable enable
-
 namespace Workstation.ServiceModel.Ua
 {
     public sealed class DataValue

--- a/UaClient/ServiceModel/Ua/DataValueExtensions.cs
+++ b/UaClient/ServiceModel/Ua/DataValueExtensions.cs
@@ -5,8 +5,6 @@ using System;
 using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 
-#nullable enable
-
 namespace Workstation.ServiceModel.Ua
 {
     public static class DataValueExtensions

--- a/UaClient/ServiceModel/Ua/DiagnosticFlags.cs
+++ b/UaClient/ServiceModel/Ua/DiagnosticFlags.cs
@@ -3,8 +3,6 @@
 
 using System;
 
-#nullable enable
-
 namespace Workstation.ServiceModel.Ua
 {
     [Flags]

--- a/UaClient/ServiceModel/Ua/DiagnosticInfo.cs
+++ b/UaClient/ServiceModel/Ua/DiagnosticInfo.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright (c) Converter Systems LLC. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-#nullable enable
-
 namespace Workstation.ServiceModel.Ua
 {
     public sealed class DiagnosticInfo

--- a/UaClient/ServiceModel/Ua/DirectoryStore.cs
+++ b/UaClient/ServiceModel/Ua/DirectoryStore.cs
@@ -19,8 +19,6 @@ using Org.BouncyCastle.X509;
 using Org.BouncyCastle.X509.Extension;
 using Org.BouncyCastle.X509.Store;
 
-#nullable enable
-
 namespace Workstation.ServiceModel.Ua
 {
     /// <summary>

--- a/UaClient/ServiceModel/Ua/EventFieldAttribute.cs
+++ b/UaClient/ServiceModel/Ua/EventFieldAttribute.cs
@@ -3,8 +3,6 @@
 
 using System;
 
-#nullable enable
-
 namespace Workstation.ServiceModel.Ua
 {
     /// <summary>

--- a/UaClient/ServiceModel/Ua/EventHelper.cs
+++ b/UaClient/ServiceModel/Ua/EventHelper.cs
@@ -6,8 +6,6 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
 
-#nullable enable
-
 namespace Workstation.ServiceModel.Ua
 {
     public static class EventHelper

--- a/UaClient/ServiceModel/Ua/EventNotifierFlags.cs
+++ b/UaClient/ServiceModel/Ua/EventNotifierFlags.cs
@@ -3,8 +3,6 @@
 
 using System;
 
-#nullable enable
-
 namespace Workstation.ServiceModel.Ua
 {
     [Flags]

--- a/UaClient/ServiceModel/Ua/ExpandedNodeId.cs
+++ b/UaClient/ServiceModel/Ua/ExpandedNodeId.cs
@@ -7,8 +7,6 @@ using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
 using System.Text;
 
-#nullable enable
-
 namespace Workstation.ServiceModel.Ua
 {
     public sealed class ExpandedNodeId : IEquatable<ExpandedNodeId>

--- a/UaClient/ServiceModel/Ua/ExtensionObject.cs
+++ b/UaClient/ServiceModel/Ua/ExtensionObject.cs
@@ -5,8 +5,6 @@ using System.Linq;
 using System.Reflection;
 using System.Xml.Linq;
 
-#nullable enable
-
 namespace Workstation.ServiceModel.Ua
 {
     public enum BodyType

--- a/UaClient/ServiceModel/Ua/ICertificateStore.cs
+++ b/UaClient/ServiceModel/Ua/ICertificateStore.cs
@@ -7,8 +7,6 @@ using Microsoft.Extensions.Logging;
 using Org.BouncyCastle.Crypto.Parameters;
 using Org.BouncyCastle.X509;
 
-#nullable enable
-
 namespace Workstation.ServiceModel.Ua
 {
     /// <summary>

--- a/UaClient/ServiceModel/Ua/ICommunicationObject.cs
+++ b/UaClient/ServiceModel/Ua/ICommunicationObject.cs
@@ -4,8 +4,6 @@
 using System.Threading;
 using System.Threading.Tasks;
 
-#nullable enable
-
 namespace Workstation.ServiceModel.Ua
 {
     /// <summary>Defines the contract for the basic state machine for all communication-oriented objects in the system.</summary>

--- a/UaClient/ServiceModel/Ua/ICommunicationObject.cs
+++ b/UaClient/ServiceModel/Ua/ICommunicationObject.cs
@@ -18,16 +18,16 @@ namespace Workstation.ServiceModel.Ua
         /// <summary>Causes a communication object to transition immediately from its current state into the closed state.  </summary>
         /// <param name="token">The <see cref="T:System.Threading.CancellationToken" /> that notifies that the task should be canceled.</param>
         /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
-        Task AbortAsync(CancellationToken token = default(CancellationToken));
+        Task AbortAsync(CancellationToken token = default);
 
         /// <summary>Causes a communication object to transition from its current state into the closed state.  </summary>
         /// <param name="token">The <see cref="T:System.Threading.CancellationToken" /> that notifies that the task should be canceled.</param>
         /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
-        Task CloseAsync(CancellationToken token = default(CancellationToken));
+        Task CloseAsync(CancellationToken token = default);
 
         /// <summary>Causes a communication object to transition from the created state into the opened state.  </summary>
         /// <param name="token">The <see cref="T:System.Threading.CancellationToken" /> that notifies that the task should be canceled.</param>
         /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
-        Task OpenAsync(CancellationToken token = default(CancellationToken));
+        Task OpenAsync(CancellationToken token = default);
     }
 }

--- a/UaClient/ServiceModel/Ua/IDecoder.cs
+++ b/UaClient/ServiceModel/Ua/IDecoder.cs
@@ -4,8 +4,6 @@
 using System;
 using System.Xml.Linq;
 
-#nullable enable
-
 namespace Workstation.ServiceModel.Ua
 {
     public interface IDecoder

--- a/UaClient/ServiceModel/Ua/IEncodable.cs
+++ b/UaClient/ServiceModel/Ua/IEncodable.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright (c) Converter Systems LLC. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-#nullable enable
-
 namespace Workstation.ServiceModel.Ua
 {
     public interface IEncodable

--- a/UaClient/ServiceModel/Ua/IEncoder.cs
+++ b/UaClient/ServiceModel/Ua/IEncoder.cs
@@ -4,8 +4,6 @@
 using System;
 using System.Xml.Linq;
 
-#nullable enable
-
 namespace Workstation.ServiceModel.Ua
 {
     public interface IEncoder

--- a/UaClient/ServiceModel/Ua/IRequestChannel.cs
+++ b/UaClient/ServiceModel/Ua/IRequestChannel.cs
@@ -4,8 +4,6 @@
 using System.Threading;
 using System.Threading.Tasks;
 
-#nullable enable
-
 namespace Workstation.ServiceModel.Ua
 {
     /// <summary>

--- a/UaClient/ServiceModel/Ua/IRequestChannel.cs
+++ b/UaClient/ServiceModel/Ua/IRequestChannel.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Converter Systems LLC. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using System.Threading;
 using System.Threading.Tasks;
 
 #nullable enable
@@ -15,6 +16,7 @@ namespace Workstation.ServiceModel.Ua
         /// <summary>Sends an IServiceRequest and returns the correlated IServiceResponse.</summary>
         /// <returns>The <see cref="T:ConverterSystems.ServiceModel.Ua.IServiceResponse" /> received in response to the request. </returns>
         /// <param name="request">The <see cref="T:ConverterSystems.ServiceModel.Ua.IServiceRequest" /> to be transmitted.</param>
-        Task<IServiceResponse> RequestAsync(IServiceRequest request);
+        /// <param name="token">Optional <see cref="T:System.Threading.CancellationToken" />.</param>
+        Task<IServiceResponse> RequestAsync(IServiceRequest request, CancellationToken token = default);
     }
 }

--- a/UaClient/ServiceModel/Ua/IServiceRequest.cs
+++ b/UaClient/ServiceModel/Ua/IServiceRequest.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright (c) Converter Systems LLC. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-#nullable enable
-
 namespace Workstation.ServiceModel.Ua
 {
     public interface IServiceRequest : IEncodable

--- a/UaClient/ServiceModel/Ua/IServiceResponse.cs
+++ b/UaClient/ServiceModel/Ua/IServiceResponse.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright (c) Converter Systems LLC. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-#nullable enable
-
 namespace Workstation.ServiceModel.Ua
 {
     public interface IServiceResponse : IEncodable

--- a/UaClient/ServiceModel/Ua/ISetDataErrorInfo.cs
+++ b/UaClient/ServiceModel/Ua/ISetDataErrorInfo.cs
@@ -3,8 +3,6 @@
 
 using System.Collections.Generic;
 
-#nullable enable
-
 namespace Workstation.ServiceModel.Ua
 {
     /// <summary>

--- a/UaClient/ServiceModel/Ua/IUserIdentity.cs
+++ b/UaClient/ServiceModel/Ua/IUserIdentity.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright (c) Converter Systems LLC. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-#nullable enable
-
 namespace Workstation.ServiceModel.Ua
 {
     public class IUserIdentity

--- a/UaClient/ServiceModel/Ua/IssuedIdentity.cs
+++ b/UaClient/ServiceModel/Ua/IssuedIdentity.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright (c) Converter Systems LLC. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-#nullable enable
-
 namespace Workstation.ServiceModel.Ua
 {
     public class IssuedIdentity : IUserIdentity

--- a/UaClient/ServiceModel/Ua/LocalizedText.cs
+++ b/UaClient/ServiceModel/Ua/LocalizedText.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright (c) Converter Systems LLC. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-#nullable enable
-
 namespace Workstation.ServiceModel.Ua
 {
     public sealed class LocalizedText

--- a/UaClient/ServiceModel/Ua/MappedEndpoint.cs
+++ b/UaClient/ServiceModel/Ua/MappedEndpoint.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright (c) Converter Systems LLC. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-#nullable enable
-
 namespace Workstation.ServiceModel.Ua
 {
     /// <summary>

--- a/UaClient/ServiceModel/Ua/MethodServiceSet.cs
+++ b/UaClient/ServiceModel/Ua/MethodServiceSet.cs
@@ -2,8 +2,8 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
+using System.Threading;
 using System.Threading.Tasks;
-using Workstation.ServiceModel.Ua.Channels;
 
 #nullable enable
 
@@ -17,14 +17,14 @@ namespace Workstation.ServiceModel.Ua
         /// <param name="channel">A instance of <see cref="IRequestChannel"/>.</param>
         /// <param name="request">A <see cref="CallRequest"/>.</param>
         /// <returns>A <see cref="Task"/> representing the asynchronous operation that returns a <see cref="CallResponse"/>.</returns>
-        public static async Task<CallResponse> CallAsync(this IRequestChannel channel, CallRequest request)
+        public static async Task<CallResponse> CallAsync(this IRequestChannel channel, CallRequest request, CancellationToken token = default)
         {
             if (request == null)
             {
                 throw new ArgumentNullException(nameof(request));
             }
 
-            return (CallResponse)await channel.RequestAsync(request).ConfigureAwait(false);
+            return (CallResponse)await channel.RequestAsync(request, token).ConfigureAwait(false);
         }
 
     }

--- a/UaClient/ServiceModel/Ua/MethodServiceSet.cs
+++ b/UaClient/ServiceModel/Ua/MethodServiceSet.cs
@@ -5,8 +5,6 @@ using System;
 using System.Threading;
 using System.Threading.Tasks;
 
-#nullable enable
-
 namespace Workstation.ServiceModel.Ua
 {
     public static class MethodServiceSet

--- a/UaClient/ServiceModel/Ua/MonitoredItemAttribute.cs
+++ b/UaClient/ServiceModel/Ua/MonitoredItemAttribute.cs
@@ -3,8 +3,6 @@
 
 using System;
 
-#nullable enable
-
 namespace Workstation.ServiceModel.Ua
 {
     /// <summary>

--- a/UaClient/ServiceModel/Ua/MonitoredItemBase.cs
+++ b/UaClient/ServiceModel/Ua/MonitoredItemBase.cs
@@ -7,8 +7,6 @@ using System.Reflection;
 using System.Threading;
 using Workstation.Collections;
 
-#nullable enable
-
 namespace Workstation.ServiceModel.Ua
 {
     /// <summary>

--- a/UaClient/ServiceModel/Ua/MonitoredItemCollection.cs
+++ b/UaClient/ServiceModel/Ua/MonitoredItemCollection.cs
@@ -6,8 +6,6 @@ using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Diagnostics.CodeAnalysis;
 
-#nullable enable
-
 namespace Workstation.ServiceModel.Ua
 {
     /// <summary>

--- a/UaClient/ServiceModel/Ua/MonitoredItemServiceSet.cs
+++ b/UaClient/ServiceModel/Ua/MonitoredItemServiceSet.cs
@@ -5,8 +5,6 @@ using System;
 using System.Threading;
 using System.Threading.Tasks;
 
-#nullable enable
-
 namespace Workstation.ServiceModel.Ua
 {
     public static class MonitoredItemServiceSet

--- a/UaClient/ServiceModel/Ua/MonitoredItemServiceSet.cs
+++ b/UaClient/ServiceModel/Ua/MonitoredItemServiceSet.cs
@@ -2,8 +2,8 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
+using System.Threading;
 using System.Threading.Tasks;
-using Workstation.ServiceModel.Ua.Channels;
 
 #nullable enable
 
@@ -17,14 +17,14 @@ namespace Workstation.ServiceModel.Ua
         /// <param name="channel">A instance of <see cref="IRequestChannel"/>.</param>
         /// <param name="request">A <see cref="CreateMonitoredItemsRequest"/>.</param>
         /// <returns>A <see cref="Task"/> representing the asynchronous operation that returns a <see cref="CreateMonitoredItemsResponse"/>.</returns>
-        public static async Task<CreateMonitoredItemsResponse> CreateMonitoredItemsAsync(this IRequestChannel channel, CreateMonitoredItemsRequest request)
+        public static async Task<CreateMonitoredItemsResponse> CreateMonitoredItemsAsync(this IRequestChannel channel, CreateMonitoredItemsRequest request, CancellationToken token = default)
         {
             if (request == null)
             {
                 throw new ArgumentNullException(nameof(request));
             }
 
-            return (CreateMonitoredItemsResponse)await channel.RequestAsync(request).ConfigureAwait(false);
+            return (CreateMonitoredItemsResponse)await channel.RequestAsync(request, token).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -33,14 +33,14 @@ namespace Workstation.ServiceModel.Ua
         /// <param name="channel">A instance of <see cref="IRequestChannel"/>.</param>
         /// <param name="request">A <see cref="ModifyMonitoredItemsRequest"/>.</param>
         /// <returns>A <see cref="Task"/> representing the asynchronous operation that returns a <see cref="ModifyMonitoredItemsResponse"/>.</returns>
-        public static async Task<ModifyMonitoredItemsResponse> ModifyMonitoredItemsAsync(this IRequestChannel channel, ModifyMonitoredItemsRequest request)
+        public static async Task<ModifyMonitoredItemsResponse> ModifyMonitoredItemsAsync(this IRequestChannel channel, ModifyMonitoredItemsRequest request, CancellationToken token = default)
         {
             if (request == null)
             {
                 throw new ArgumentNullException(nameof(request));
             }
 
-            return (ModifyMonitoredItemsResponse)await channel.RequestAsync(request).ConfigureAwait(false);
+            return (ModifyMonitoredItemsResponse)await channel.RequestAsync(request, token).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -49,14 +49,14 @@ namespace Workstation.ServiceModel.Ua
         /// <param name="channel">A instance of <see cref="IRequestChannel"/>.</param>
         /// <param name="request">A <see cref="SetMonitoringModeRequest"/>.</param>
         /// <returns>A <see cref="Task"/> representing the asynchronous operation that returns a <see cref="SetMonitoringModeResponse"/>.</returns>
-        public static async Task<SetMonitoringModeResponse> SetMonitoringModeAsync(this IRequestChannel channel, SetMonitoringModeRequest request)
+        public static async Task<SetMonitoringModeResponse> SetMonitoringModeAsync(this IRequestChannel channel, SetMonitoringModeRequest request, CancellationToken token = default)
         {
             if (request == null)
             {
                 throw new ArgumentNullException(nameof(request));
             }
 
-            return (SetMonitoringModeResponse)await channel.RequestAsync(request).ConfigureAwait(false);
+            return (SetMonitoringModeResponse)await channel.RequestAsync(request, token).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -65,14 +65,14 @@ namespace Workstation.ServiceModel.Ua
         /// <param name="channel">A instance of <see cref="IRequestChannel"/>.</param>
         /// <param name="request">A <see cref="SetTriggeringRequest"/>.</param>
         /// <returns>A <see cref="Task"/> representing the asynchronous operation that returns a <see cref="SetTriggeringResponse"/>.</returns>
-        public static async Task<SetTriggeringResponse> SetTriggeringAsync(this IRequestChannel channel, SetTriggeringRequest request)
+        public static async Task<SetTriggeringResponse> SetTriggeringAsync(this IRequestChannel channel, SetTriggeringRequest request, CancellationToken token = default)
         {
             if (request == null)
             {
                 throw new ArgumentNullException(nameof(request));
             }
 
-            return (SetTriggeringResponse)await channel.RequestAsync(request).ConfigureAwait(false);
+            return (SetTriggeringResponse)await channel.RequestAsync(request, token).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -81,14 +81,14 @@ namespace Workstation.ServiceModel.Ua
         /// <param name="channel">A instance of <see cref="IRequestChannel"/>.</param>
         /// <param name="request">A <see cref="DeleteMonitoredItemsRequest"/>.</param>
         /// <returns>A <see cref="Task"/> representing the asynchronous operation that returns a <see cref="DeleteMonitoredItemsResponse"/>.</returns>
-        public static async Task<DeleteMonitoredItemsResponse> DeleteMonitoredItemsAsync(this IRequestChannel channel, DeleteMonitoredItemsRequest request)
+        public static async Task<DeleteMonitoredItemsResponse> DeleteMonitoredItemsAsync(this IRequestChannel channel, DeleteMonitoredItemsRequest request, CancellationToken token = default)
         {
             if (request == null)
             {
                 throw new ArgumentNullException(nameof(request));
             }
 
-            return (DeleteMonitoredItemsResponse)await channel.RequestAsync(request).ConfigureAwait(false);
+            return (DeleteMonitoredItemsResponse)await channel.RequestAsync(request, token).ConfigureAwait(false);
         }
 
     }

--- a/UaClient/ServiceModel/Ua/NodeId.cs
+++ b/UaClient/ServiceModel/Ua/NodeId.cs
@@ -8,8 +8,6 @@ using System.Globalization;
 using System.Linq;
 using System.Text;
 
-#nullable enable
-
 namespace Workstation.ServiceModel.Ua
 {
     public class NodeId : IEquatable<NodeId>

--- a/UaClient/ServiceModel/Ua/NodeManagementServiceSet.cs
+++ b/UaClient/ServiceModel/Ua/NodeManagementServiceSet.cs
@@ -5,8 +5,6 @@ using System;
 using System.Threading;
 using System.Threading.Tasks;
 
-#nullable enable
-
 namespace Workstation.ServiceModel.Ua
 {
     public static class NodeManagementServiceSet

--- a/UaClient/ServiceModel/Ua/NodeManagementServiceSet.cs
+++ b/UaClient/ServiceModel/Ua/NodeManagementServiceSet.cs
@@ -2,8 +2,8 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
+using System.Threading;
 using System.Threading.Tasks;
-using Workstation.ServiceModel.Ua.Channels;
 
 #nullable enable
 
@@ -17,14 +17,14 @@ namespace Workstation.ServiceModel.Ua
         /// <param name="channel">A instance of <see cref="IRequestChannel"/>.</param>
         /// <param name="request">A <see cref="AddNodesRequest"/>.</param>
         /// <returns>A <see cref="Task"/> representing the asynchronous operation that returns a <see cref="AddNodesResponse"/>.</returns>
-        public static async Task<AddNodesResponse> AddNodesAsync(this IRequestChannel channel, AddNodesRequest request)
+        public static async Task<AddNodesResponse> AddNodesAsync(this IRequestChannel channel, AddNodesRequest request, CancellationToken token = default)
         {
             if (request == null)
             {
                 throw new ArgumentNullException(nameof(request));
             }
 
-            return (AddNodesResponse)await channel.RequestAsync(request).ConfigureAwait(false);
+            return (AddNodesResponse)await channel.RequestAsync(request, token).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -33,14 +33,14 @@ namespace Workstation.ServiceModel.Ua
         /// <param name="channel">A instance of <see cref="IRequestChannel"/>.</param>
         /// <param name="request">A <see cref="AddReferencesRequest"/>.</param>
         /// <returns>A <see cref="Task"/> representing the asynchronous operation that returns a <see cref="AddReferencesResponse"/>.</returns>
-        public static async Task<AddReferencesResponse> AddReferencesAsync(this IRequestChannel channel, AddReferencesRequest request)
+        public static async Task<AddReferencesResponse> AddReferencesAsync(this IRequestChannel channel, AddReferencesRequest request, CancellationToken token = default)
         {
             if (request == null)
             {
                 throw new ArgumentNullException(nameof(request));
             }
 
-            return (AddReferencesResponse)await channel.RequestAsync(request).ConfigureAwait(false);
+            return (AddReferencesResponse)await channel.RequestAsync(request, token).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -49,14 +49,14 @@ namespace Workstation.ServiceModel.Ua
         /// <param name="channel">A instance of <see cref="IRequestChannel"/>.</param>
         /// <param name="request">A <see cref="DeleteNodesRequest"/>.</param>
         /// <returns>A <see cref="Task"/> representing the asynchronous operation that returns a <see cref="DeleteNodesResponse"/>.</returns>
-        public static async Task<DeleteNodesResponse> DeleteNodesAsync(this IRequestChannel channel, DeleteNodesRequest request)
+        public static async Task<DeleteNodesResponse> DeleteNodesAsync(this IRequestChannel channel, DeleteNodesRequest request, CancellationToken token = default)
         {
             if (request == null)
             {
                 throw new ArgumentNullException(nameof(request));
             }
 
-            return (DeleteNodesResponse)await channel.RequestAsync(request).ConfigureAwait(false);
+            return (DeleteNodesResponse)await channel.RequestAsync(request, token).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -65,14 +65,14 @@ namespace Workstation.ServiceModel.Ua
         /// <param name="channel">A instance of <see cref="IRequestChannel"/>.</param>
         /// <param name="request">A <see cref="DeleteReferencesRequest"/>.</param>
         /// <returns>A <see cref="Task"/> representing the asynchronous operation that returns a <see cref="DeleteReferencesResponse"/>.</returns>
-        public static async Task<DeleteReferencesResponse> DeleteReferencesAsync(this IRequestChannel channel, DeleteReferencesRequest request)
+        public static async Task<DeleteReferencesResponse> DeleteReferencesAsync(this IRequestChannel channel, DeleteReferencesRequest request, CancellationToken token = default)
         {
             if (request == null)
             {
                 throw new ArgumentNullException(nameof(request));
             }
 
-            return (DeleteReferencesResponse)await channel.RequestAsync(request).ConfigureAwait(false);
+            return (DeleteReferencesResponse)await channel.RequestAsync(request, token).ConfigureAwait(false);
         }
     }
 }

--- a/UaClient/ServiceModel/Ua/QualifiedName.cs
+++ b/UaClient/ServiceModel/Ua/QualifiedName.cs
@@ -3,8 +3,6 @@
 
 using System;
 
-#nullable enable
-
 namespace Workstation.ServiceModel.Ua
 {
     public sealed class QualifiedName

--- a/UaClient/ServiceModel/Ua/QueryServiceSet.cs
+++ b/UaClient/ServiceModel/Ua/QueryServiceSet.cs
@@ -2,8 +2,8 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
+using System.Threading;
 using System.Threading.Tasks;
-using Workstation.ServiceModel.Ua.Channels;
 
 #nullable enable
 
@@ -17,14 +17,14 @@ namespace Workstation.ServiceModel.Ua
         /// <param name="channel">A instance of <see cref="IRequestChannel"/>.</param>
         /// <param name="request">A <see cref="QueryFirstRequest"/>.</param>
         /// <returns>A <see cref="Task"/> representing the asynchronous operation that returns a <see cref="QueryFirstResponse"/>.</returns>
-        public static async Task<QueryFirstResponse> QueryFirstAsync(this IRequestChannel channel, QueryFirstRequest request)
+        public static async Task<QueryFirstResponse> QueryFirstAsync(this IRequestChannel channel, QueryFirstRequest request, CancellationToken token = default)
         {
             if (request == null)
             {
                 throw new ArgumentNullException(nameof(request));
             }
 
-            return (QueryFirstResponse)await channel.RequestAsync(request).ConfigureAwait(false);
+            return (QueryFirstResponse)await channel.RequestAsync(request, token).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -33,14 +33,14 @@ namespace Workstation.ServiceModel.Ua
         /// <param name="channel">A instance of <see cref="IRequestChannel"/>.</param>
         /// <param name="request">A <see cref="QueryNextRequest"/>.</param>
         /// <returns>A <see cref="Task"/> representing the asynchronous operation that returns a <see cref="QueryNextResponse"/>.</returns>
-        public static async Task<QueryNextResponse> QueryNextAsync(this IRequestChannel channel, QueryNextRequest request)
+        public static async Task<QueryNextResponse> QueryNextAsync(this IRequestChannel channel, QueryNextRequest request, CancellationToken token = default)
         {
             if (request == null)
             {
                 throw new ArgumentNullException(nameof(request));
             }
 
-            return (QueryNextResponse)await channel.RequestAsync(request).ConfigureAwait(false);
+            return (QueryNextResponse)await channel.RequestAsync(request, token).ConfigureAwait(false);
         }
     }
 }

--- a/UaClient/ServiceModel/Ua/QueryServiceSet.cs
+++ b/UaClient/ServiceModel/Ua/QueryServiceSet.cs
@@ -5,8 +5,6 @@ using System;
 using System.Threading;
 using System.Threading.Tasks;
 
-#nullable enable
-
 namespace Workstation.ServiceModel.Ua
 {
     public static class QueryServiceSet

--- a/UaClient/ServiceModel/Ua/SecurityPolicyUris.cs
+++ b/UaClient/ServiceModel/Ua/SecurityPolicyUris.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright (c) Converter Systems LLC. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-#nullable enable
-
 namespace Workstation.ServiceModel.Ua
 {
     public static class SecurityPolicyUris

--- a/UaClient/ServiceModel/Ua/ServiceExtensions.cs
+++ b/UaClient/ServiceModel/Ua/ServiceExtensions.cs
@@ -6,8 +6,6 @@ using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 
-#nullable enable
-
 namespace Workstation.ServiceModel.Ua
 {
     public static class ServiceExtensions

--- a/UaClient/ServiceModel/Ua/ServiceExtensions.cs
+++ b/UaClient/ServiceModel/Ua/ServiceExtensions.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Converter Systems LLC. All rights reserved.
+// Copyright (c) Converter Systems LLC. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
@@ -30,88 +30,6 @@ namespace Workstation.ServiceModel.Ua
         public static object?[] ToObjectArray(this Variant[] array)
         {
             return array.Select(a => a.Value).ToArray();
-        }
-
-        /// <summary>
-        /// Wraps a task with one that may complete as cancelled based on a cancellation token,
-        /// allowing someone to await a task but be able to break out early by cancelling the token.
-        /// </summary>
-        /// <typeparam name="T">The type of value returned by the task.</typeparam>
-        /// <param name="task">The task to wrap.</param>
-        /// <param name="cancellationToken">The token that can be canceled to break out of the await.</param>
-        /// <returns>The wrapping task.</returns>
-        public static async Task<T> WithCancellation<T>(this Task<T> task, CancellationToken cancellationToken)
-        {
-            var tcs = new TaskCompletionSource<bool>();
-            using (cancellationToken.Register(s => ((TaskCompletionSource<bool>)s!).TrySetResult(true), tcs))
-            {
-                if (task != await Task.WhenAny(task, tcs.Task).ConfigureAwait(false))
-                {
-                    throw new OperationCanceledException(cancellationToken);
-                }
-            }
-
-            return await task.ConfigureAwait(false);
-        }
-
-        /// <summary>
-        /// Wraps a task with one that may complete as cancelled based on a cancellation token,
-        /// allowing someone to await a task but be able to break out early by cancelling the token.
-        /// </summary>
-        /// <param name="task">The task to wrap.</param>
-        /// <param name="cancellationToken">The token that can be canceled to break out of the await.</param>
-        /// <returns>The wrapping task.</returns>
-        public static async Task WithCancellation(this Task task, CancellationToken cancellationToken)
-        {
-            var tcs = new TaskCompletionSource<bool>();
-            using (cancellationToken.Register(s => ((TaskCompletionSource<bool>)s!).TrySetResult(true), tcs))
-            {
-                if (task != await Task.WhenAny(task, tcs.Task).ConfigureAwait(false))
-                {
-                    throw new OperationCanceledException(cancellationToken);
-                }
-            }
-
-            await task.ConfigureAwait(false);
-        }
-
-        /// <summary>
-        /// Wraps a task with one that may complete as faulted based on a timeout,
-        /// allowing someone to await a task but be able to break out early by a timeout.
-        /// </summary>
-        /// <typeparam name="T">The type of value returned by the task.</typeparam>
-        /// <param name="task">The task to wrap.</param>
-        /// <param name="millisecondsTimeout">The number of milliseconds to.</param>
-        /// <returns>The wrapping task.</returns>
-        public static async Task<T> WithTimeoutAfter<T>(this Task<T> task, int millisecondsTimeout)
-        {
-            if (task == await Task.WhenAny(task, Task.Delay(millisecondsTimeout)).ConfigureAwait(false))
-            {
-                return await task.ConfigureAwait(false);
-            }
-            else
-            {
-                throw new TimeoutException();
-            }
-        }
-
-        /// <summary>
-        /// Wraps a task with one that may complete as faulted based on a timeout,
-        /// allowing someone to await a task but be able to break out early by a timeout.
-        /// </summary>
-        /// <param name="task">The task to wrap.</param>
-        /// <param name="millisecondsTimeout">The number of milliseconds to.</param>
-        /// <returns>The wrapping task.</returns>
-        public static async Task WithTimeoutAfter(this Task task, int millisecondsTimeout)
-        {
-            if (task == await Task.WhenAny(task, Task.Delay(millisecondsTimeout)).ConfigureAwait(false))
-            {
-                await task.ConfigureAwait(false);
-            }
-            else
-            {
-                throw new TimeoutException();
-            }
         }
 
         /// <summary>
@@ -217,6 +135,61 @@ namespace Workstation.ServiceModel.Ua
             }
             
             return result.StatusCode;
+        }
+
+        public static async Task WithCancellation(this Task task, CancellationToken cancellationToken)
+        {
+            var tcs = new TaskCompletionSource<bool>();
+            using (cancellationToken.Register(s => ((TaskCompletionSource<bool>)s!).TrySetResult(true), tcs))
+            {
+                if (task != await Task.WhenAny(task, tcs.Task).ConfigureAwait(false))
+                {
+                    throw new OperationCanceledException(cancellationToken);
+                }
+                await task; // already completed; propagate any exception
+            }
+        }
+
+
+        public static Task TimeoutAfter(this Task task, int millisecondsTimeout)
+            => task.TimeoutAfter(TimeSpan.FromMilliseconds(millisecondsTimeout));
+
+
+        public static async Task TimeoutAfter(this Task task, TimeSpan timeout)
+        {
+            var cts = new CancellationTokenSource();
+
+
+            if (task == await Task.WhenAny(task, Task.Delay(timeout, cts.Token)).ConfigureAwait(false))
+            {
+                cts.Cancel();
+                await task.ConfigureAwait(false);
+            }
+            else
+            {
+                throw new TimeoutException($"Task timed out after {timeout}");
+            }
+        }
+
+
+        public static Task<TResult> TimeoutAfter<TResult>(this Task<TResult> task, int millisecondsTimeout)
+            => task.TimeoutAfter(TimeSpan.FromMilliseconds(millisecondsTimeout));
+
+
+        public static async Task<TResult> TimeoutAfter<TResult>(this Task<TResult> task, TimeSpan timeout)
+        {
+            var cts = new CancellationTokenSource();
+
+
+            if (task == await Task<TResult>.WhenAny(task, Task<TResult>.Delay(timeout, cts.Token)).ConfigureAwait(false))
+            {
+                cts.Cancel();
+                return await task.ConfigureAwait(false);
+            }
+            else
+            {
+                throw new TimeoutException($"Task timed out after {timeout}");
+            }
         }
     }
 }

--- a/UaClient/ServiceModel/Ua/ServiceResult.cs
+++ b/UaClient/ServiceModel/Ua/ServiceResult.cs
@@ -4,8 +4,6 @@
 using System.Collections.Generic;
 using System.Text;
 
-#nullable enable
-
 namespace Workstation.ServiceModel.Ua
 {
     /// <summary>

--- a/UaClient/ServiceModel/Ua/ServiceResultException.cs
+++ b/UaClient/ServiceModel/Ua/ServiceResultException.cs
@@ -3,8 +3,6 @@
 
 using System;
 
-#nullable enable
-
 namespace Workstation.ServiceModel.Ua
 {
     public sealed class ServiceResultException : Exception

--- a/UaClient/ServiceModel/Ua/SessionServiceSet.cs
+++ b/UaClient/ServiceModel/Ua/SessionServiceSet.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
+using System.Threading;
 using System.Threading.Tasks;
 
 #nullable enable
@@ -16,14 +17,14 @@ namespace Workstation.ServiceModel.Ua
         /// <param name="channel">A instance of <see cref="IRequestChannel"/>.</param>
         /// <param name="request">A <see cref="CreateSessionRequest"/>.</param>
         /// <returns>A <see cref="Task"/> representing the asynchronous operation that returns a <see cref="CreateSessionResponse"/>.</returns>
-        internal static async Task<CreateSessionResponse> CreateSessionAsync(this IRequestChannel channel, CreateSessionRequest request)
+        internal static async Task<CreateSessionResponse> CreateSessionAsync(this IRequestChannel channel, CreateSessionRequest request, CancellationToken token = default)
         {
             if (request == null)
             {
                 throw new ArgumentNullException(nameof(request));
             }
 
-            return (CreateSessionResponse)await channel.RequestAsync(request).ConfigureAwait(false);
+            return (CreateSessionResponse)await channel.RequestAsync(request, token).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -32,14 +33,14 @@ namespace Workstation.ServiceModel.Ua
         /// <param name="channel">A instance of <see cref="IRequestChannel"/>.</param>
         /// <param name="request">A <see cref="ActivateSessionRequest"/>.</param>
         /// <returns>A <see cref="Task"/> representing the asynchronous operation that returns a <see cref="ActivateSessionResponse"/>.</returns>
-        internal static async Task<ActivateSessionResponse> ActivateSessionAsync(this IRequestChannel channel, ActivateSessionRequest request)
+        internal static async Task<ActivateSessionResponse> ActivateSessionAsync(this IRequestChannel channel, ActivateSessionRequest request, CancellationToken token = default)
         {
             if (request == null)
             {
                 throw new ArgumentNullException(nameof(request));
             }
 
-            return (ActivateSessionResponse)await channel.RequestAsync(request).ConfigureAwait(false);
+            return (ActivateSessionResponse)await channel.RequestAsync(request, token).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -48,14 +49,14 @@ namespace Workstation.ServiceModel.Ua
         /// <param name="channel">A instance of <see cref="IRequestChannel"/>.</param>
         /// <param name="request">A <see cref="CloseSessionRequest"/>.</param>
         /// <returns>A <see cref="Task"/> representing the asynchronous operation that returns a <see cref="CloseSessionResponse"/>.</returns>
-        internal static async Task<CloseSessionResponse> CloseSessionAsync(this IRequestChannel channel, CloseSessionRequest request)
+        internal static async Task<CloseSessionResponse> CloseSessionAsync(this IRequestChannel channel, CloseSessionRequest request, CancellationToken token = default)
         {
             if (request == null)
             {
                 throw new ArgumentNullException(nameof(request));
             }
 
-            return (CloseSessionResponse)await channel.RequestAsync(request).ConfigureAwait(false);
+            return (CloseSessionResponse)await channel.RequestAsync(request, token).ConfigureAwait(false);
         }
     }
 }

--- a/UaClient/ServiceModel/Ua/SessionServiceSet.cs
+++ b/UaClient/ServiceModel/Ua/SessionServiceSet.cs
@@ -5,8 +5,6 @@ using System;
 using System.Threading;
 using System.Threading.Tasks;
 
-#nullable enable
-
 namespace Workstation.ServiceModel.Ua
 {
     public static class SessionServiceSet

--- a/UaClient/ServiceModel/Ua/StatusCode.cs
+++ b/UaClient/ServiceModel/Ua/StatusCode.cs
@@ -5,7 +5,7 @@
 
 namespace Workstation.ServiceModel.Ua
 {
-    public struct StatusCode
+    public readonly struct StatusCode
     {
         private const uint SeverityMask = 0xC0000000u;
         private const uint SeverityGood = 0x00000000u;

--- a/UaClient/ServiceModel/Ua/StatusCode.cs
+++ b/UaClient/ServiceModel/Ua/StatusCode.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright (c) Converter Systems LLC. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-#nullable enable
-
 namespace Workstation.ServiceModel.Ua
 {
     public readonly struct StatusCode

--- a/UaClient/ServiceModel/Ua/Structure.cs
+++ b/UaClient/ServiceModel/Ua/Structure.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright (c) Converter Systems LLC. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-#nullable enable
-
 namespace Workstation.ServiceModel.Ua
 {
     /// <summary>

--- a/UaClient/ServiceModel/Ua/SubscriptionAttribute.cs
+++ b/UaClient/ServiceModel/Ua/SubscriptionAttribute.cs
@@ -3,8 +3,6 @@
 
 using System;
 
-#nullable enable
-
 namespace Workstation.ServiceModel.Ua
 {
     /// <summary>

--- a/UaClient/ServiceModel/Ua/SubscriptionBase.cs
+++ b/UaClient/ServiceModel/Ua/SubscriptionBase.cs
@@ -495,7 +495,7 @@ namespace Workstation.ServiceModel.Ua
         /// <param name="channel">The session channel. </param>
         /// <param name="token">A cancellation token. </param>
         /// <returns>A task.</returns>
-        private async Task WhenChannelClosingAsync(UaTcpSessionChannel channel, CancellationToken token = default(CancellationToken))
+        private async Task WhenChannelClosingAsync(UaTcpSessionChannel channel, CancellationToken token = default)
         {
             var tcs = new TaskCompletionSource<bool>();
             EventHandler handler = (o, e) =>
@@ -524,7 +524,7 @@ namespace Workstation.ServiceModel.Ua
         /// </summary>
         /// <param name="token">A cancellation token.</param>
         /// <returns>A task.</returns>
-        private async Task StateMachineAsync(CancellationToken token = default(CancellationToken))
+        private async Task StateMachineAsync(CancellationToken token = default)
         {
             while (!token.IsCancellationRequested)
             {

--- a/UaClient/ServiceModel/Ua/SubscriptionBase.cs
+++ b/UaClient/ServiceModel/Ua/SubscriptionBase.cs
@@ -15,8 +15,6 @@ using Microsoft.Extensions.Logging;
 using Workstation.Collections;
 using Workstation.ServiceModel.Ua.Channels;
 
-#nullable enable
-
 namespace Workstation.ServiceModel.Ua
 {
     /// <summary>

--- a/UaClient/ServiceModel/Ua/SubscriptionServiceSet.cs
+++ b/UaClient/ServiceModel/Ua/SubscriptionServiceSet.cs
@@ -3,7 +3,7 @@
 
 using System;
 using System.Threading.Tasks;
-using System.ComponentModel;
+using System.Threading;
 
 #nullable enable
 
@@ -17,14 +17,14 @@ namespace Workstation.ServiceModel.Ua
         /// <param name="channel">A instance of <see cref="IRequestChannel"/>.</param>
         /// <param name="request">A <see cref="CreateSubscriptionRequest"/>.</param>
         /// <returns>A <see cref="Task"/> representing the asynchronous operation that returns a <see cref="CreateSubscriptionResponse"/>.</returns>
-        public static async Task<CreateSubscriptionResponse> CreateSubscriptionAsync(this IRequestChannel channel, CreateSubscriptionRequest request)
+        public static async Task<CreateSubscriptionResponse> CreateSubscriptionAsync(this IRequestChannel channel, CreateSubscriptionRequest request, CancellationToken token = default)
         {
             if (request == null)
             {
                 throw new ArgumentNullException(nameof(request));
             }
 
-            return (CreateSubscriptionResponse)await channel.RequestAsync(request).ConfigureAwait(false);
+            return (CreateSubscriptionResponse)await channel.RequestAsync(request, token).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -33,14 +33,14 @@ namespace Workstation.ServiceModel.Ua
         /// <param name="channel">A instance of <see cref="IRequestChannel"/>.</param>
         /// <param name="request">A <see cref="ModifySubscriptionRequest"/>.</param>
         /// <returns>A <see cref="Task"/> representing the asynchronous operation that returns a <see cref="ModifySubscriptionResponse"/>.</returns>
-        public static async Task<ModifySubscriptionResponse> ModifySubscriptionAsync(this IRequestChannel channel, ModifySubscriptionRequest request)
+        public static async Task<ModifySubscriptionResponse> ModifySubscriptionAsync(this IRequestChannel channel, ModifySubscriptionRequest request, CancellationToken token = default)
         {
             if (request == null)
             {
                 throw new ArgumentNullException(nameof(request));
             }
 
-            return (ModifySubscriptionResponse)await channel.RequestAsync(request).ConfigureAwait(false);
+            return (ModifySubscriptionResponse)await channel.RequestAsync(request, token).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -49,14 +49,14 @@ namespace Workstation.ServiceModel.Ua
         /// <param name="channel">A instance of <see cref="IRequestChannel"/>.</param>
         /// <param name="request">A <see cref="SetPublishingModeRequest"/>.</param>
         /// <returns>A <see cref="Task"/> representing the asynchronous operation that returns a <see cref="SetPublishingModeResponse"/>.</returns>
-        public static async Task<SetPublishingModeResponse> SetPublishingModeAsync(this IRequestChannel channel, SetPublishingModeRequest request)
+        public static async Task<SetPublishingModeResponse> SetPublishingModeAsync(this IRequestChannel channel, SetPublishingModeRequest request, CancellationToken token = default)
         {
             if (request == null)
             {
                 throw new ArgumentNullException(nameof(request));
             }
 
-            return (SetPublishingModeResponse)await channel.RequestAsync(request).ConfigureAwait(false);
+            return (SetPublishingModeResponse)await channel.RequestAsync(request, token).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -65,14 +65,14 @@ namespace Workstation.ServiceModel.Ua
         /// <param name="channel">A instance of <see cref="IRequestChannel"/>.</param>
         /// <param name="request">A <see cref="PublishRequest"/>.</param>
         /// <returns>A <see cref="Task"/> representing the asynchronous operation that returns a <see cref="PublishResponse"/>.</returns>
-        internal static async Task<PublishResponse> PublishAsync(this IRequestChannel channel, PublishRequest request)
+        internal static async Task<PublishResponse> PublishAsync(this IRequestChannel channel, PublishRequest request, CancellationToken token = default)
         {
             if (request == null)
             {
                 throw new ArgumentNullException(nameof(request));
             }
 
-            return (PublishResponse)await channel.RequestAsync(request).ConfigureAwait(false);
+            return (PublishResponse)await channel.RequestAsync(request, token).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -81,14 +81,14 @@ namespace Workstation.ServiceModel.Ua
         /// <param name="channel">A instance of <see cref="IRequestChannel"/>.</param>
         /// <param name="request">A <see cref="RepublishRequest"/>.</param>
         /// <returns>A <see cref="Task"/> representing the asynchronous operation that returns a <see cref="RepublishResponse"/>.</returns>
-        internal static async Task<RepublishResponse> RepublishAsync(this IRequestChannel channel, RepublishRequest request)
+        internal static async Task<RepublishResponse> RepublishAsync(this IRequestChannel channel, RepublishRequest request, CancellationToken token = default)
         {
             if (request == null)
             {
                 throw new ArgumentNullException(nameof(request));
             }
 
-            return (RepublishResponse)await channel.RequestAsync(request).ConfigureAwait(false);
+            return (RepublishResponse)await channel.RequestAsync(request, token).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -97,14 +97,14 @@ namespace Workstation.ServiceModel.Ua
         /// <param name="channel">A instance of <see cref="IRequestChannel"/>.</param>
         /// <param name="request">A <see cref="TransferSubscriptionsRequest"/>.</param>
         /// <returns>A <see cref="Task"/> representing the asynchronous operation that returns a <see cref="TransferSubscriptionsResponse"/>.</returns>
-        public static async Task<TransferSubscriptionsResponse> TransferSubscriptionsAsync(this IRequestChannel channel, TransferSubscriptionsRequest request)
+        public static async Task<TransferSubscriptionsResponse> TransferSubscriptionsAsync(this IRequestChannel channel, TransferSubscriptionsRequest request, CancellationToken token = default)
         {
             if (request == null)
             {
                 throw new ArgumentNullException(nameof(request));
             }
 
-            return (TransferSubscriptionsResponse)await channel.RequestAsync(request).ConfigureAwait(false);
+            return (TransferSubscriptionsResponse)await channel.RequestAsync(request, token).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -113,14 +113,14 @@ namespace Workstation.ServiceModel.Ua
         /// <param name="channel">A instance of <see cref="IRequestChannel"/>.</param>
         /// <param name="request">A <see cref="DeleteSubscriptionsRequest"/>.</param>
         /// <returns>A <see cref="Task"/> representing the asynchronous operation that returns a <see cref="DeleteSubscriptionsResponse"/>.</returns>
-        public static async Task<DeleteSubscriptionsResponse> DeleteSubscriptionsAsync(this IRequestChannel channel, DeleteSubscriptionsRequest request)
+        public static async Task<DeleteSubscriptionsResponse> DeleteSubscriptionsAsync(this IRequestChannel channel, DeleteSubscriptionsRequest request, CancellationToken token = default)
         {
             if (request == null)
             {
                 throw new ArgumentNullException(nameof(request));
             }
 
-            return (DeleteSubscriptionsResponse)await channel.RequestAsync(request).ConfigureAwait(false);
+            return (DeleteSubscriptionsResponse)await channel.RequestAsync(request, token).ConfigureAwait(false);
         }
     }
 }

--- a/UaClient/ServiceModel/Ua/SubscriptionServiceSet.cs
+++ b/UaClient/ServiceModel/Ua/SubscriptionServiceSet.cs
@@ -5,8 +5,6 @@ using System;
 using System.Threading.Tasks;
 using System.Threading;
 
-#nullable enable
-
 namespace Workstation.ServiceModel.Ua
 {
     public static class SubscriptionServiceSet

--- a/UaClient/ServiceModel/Ua/TransportProfileUris.cs
+++ b/UaClient/ServiceModel/Ua/TransportProfileUris.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright (c) Converter Systems LLC. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-#nullable enable
-
 namespace Workstation.ServiceModel.Ua
 {
     public static class TransportProfileUris

--- a/UaClient/ServiceModel/Ua/Types.generated.cs
+++ b/UaClient/ServiceModel/Ua/Types.generated.cs
@@ -8,6 +8,7 @@
 // </auto-generated>
 // ------------------------------------------------------------------------------
 
+// Auto-generated code requires an explicit `#nullable` directive in source.
 #nullable enable
 
 namespace Workstation.ServiceModel.Ua

--- a/UaClient/ServiceModel/Ua/Types.tt
+++ b/UaClient/ServiceModel/Ua/Types.tt
@@ -57,6 +57,7 @@ try
 // </auto-generated>
 // ------------------------------------------------------------------------------
 
+// Auto-generated code requires an explicit `#nullable` directive in source.
 #nullable enable
 
 namespace Workstation.ServiceModel.Ua

--- a/UaClient/ServiceModel/Ua/UaApplication.cs
+++ b/UaClient/ServiceModel/Ua/UaApplication.cs
@@ -10,8 +10,6 @@ using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
 using Workstation.ServiceModel.Ua.Channels;
 
-#nullable enable
-
 namespace Workstation.ServiceModel.Ua
 {
     /// <summary>

--- a/UaClient/ServiceModel/Ua/UaApplication.cs
+++ b/UaClient/ServiceModel/Ua/UaApplication.cs
@@ -201,7 +201,7 @@ namespace Workstation.ServiceModel.Ua
         /// </summary>
         /// <param name="token">A cancellation token.</param>
         /// <returns>A task.</returns>
-        private Task CheckSuspension(CancellationToken token = default(CancellationToken))
+        private Task CheckSuspension(CancellationToken token = default)
         {
             return this.suspensionTask.Task.WithCancellation(token);
         }
@@ -212,7 +212,7 @@ namespace Workstation.ServiceModel.Ua
         /// <param name="endpointUrl">The endpoint url of the OPC UA server</param>
         /// <param name="token">A cancellation token.</param>
         /// <returns>A <see cref="UaTcpSessionChannel"/>.</returns>
-        public async Task<UaTcpSessionChannel> GetChannelAsync(string endpointUrl, CancellationToken token = default(CancellationToken))
+        public async Task<UaTcpSessionChannel> GetChannelAsync(string endpointUrl, CancellationToken token = default)
         {
             this.logger?.LogTrace($"Begin getting UaTcpSessionChannel for {endpointUrl}");
             if (string.IsNullOrEmpty(endpointUrl))
@@ -225,13 +225,12 @@ namespace Workstation.ServiceModel.Ua
             var ch = await this.channelMap
                 .GetOrAdd(endpointUrl, k => new Lazy<Task<UaTcpSessionChannel>>(() => Task.Run(() => this.CreateChannelAsync(k, token))))
                 .Value
-                .WithCancellation(token)
                 .ConfigureAwait(false);
 
             return ch;
         }
 
-        private async Task<UaTcpSessionChannel> CreateChannelAsync(string endpointUrl, CancellationToken token = default(CancellationToken))
+        private async Task<UaTcpSessionChannel> CreateChannelAsync(string endpointUrl, CancellationToken token = default)
         {
             try
             {
@@ -285,7 +284,6 @@ namespace Workstation.ServiceModel.Ua
             catch (Exception ex)
             {
                 this.logger?.LogTrace($"Error creating UaTcpSessionChannel for {endpointUrl}. {ex.Message}");
-                this.channelMap.TryRemove(endpointUrl, out _);
                 throw;
             }
         }

--- a/UaClient/ServiceModel/Ua/UaApplicationBuilder.cs
+++ b/UaClient/ServiceModel/Ua/UaApplicationBuilder.cs
@@ -7,8 +7,6 @@ using System.Threading.Tasks;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Logging;
 
-#nullable enable
-
 namespace Workstation.ServiceModel.Ua
 {
     /// <summary>

--- a/UaClient/ServiceModel/Ua/UaApplicationOptions.cs
+++ b/UaClient/ServiceModel/Ua/UaApplicationOptions.cs
@@ -7,8 +7,6 @@ using System.Text;
 using Workstation.ServiceModel.Ua;
 using Workstation.ServiceModel.Ua.Channels;
 
-#nullable enable
-
 namespace Workstation.ServiceModel.Ua
 {
     /// <summary>

--- a/UaClient/ServiceModel/Ua/UaTcpDiscoveryService.cs
+++ b/UaClient/ServiceModel/Ua/UaTcpDiscoveryService.cs
@@ -7,8 +7,6 @@ using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
 using Workstation.ServiceModel.Ua.Channels;
 
-#nullable enable
-
 namespace Workstation.ServiceModel.Ua
 {
     /// <summary>

--- a/UaClient/ServiceModel/Ua/UaTcpDiscoveryService.cs
+++ b/UaClient/ServiceModel/Ua/UaTcpDiscoveryService.cs
@@ -14,7 +14,7 @@ namespace Workstation.ServiceModel.Ua
     /// <summary>
     /// A service for discovery of remote OPC UA servers and their endpoints.
     /// </summary>
-    public class UaTcpDiscoveryService : ICommunicationObject, IDisposable
+    public class UaTcpDiscoveryService : ICommunicationObject
     {
         private readonly UaTcpSecureChannel innerChannel;
         private readonly SemaphoreSlim semaphore;
@@ -114,7 +114,7 @@ namespace Workstation.ServiceModel.Ua
         /// </summary>
         /// <param name="token">The <see cref="T:System.Threading.CancellationToken" /> that notifies when the task should be canceled.</param>
         /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
-        public async Task AbortAsync(CancellationToken token = default(CancellationToken))
+        public async Task AbortAsync(CancellationToken token = default)
         {
             await this.semaphore.WaitAsync(token).ConfigureAwait(false);
             try
@@ -132,7 +132,7 @@ namespace Workstation.ServiceModel.Ua
         /// </summary>
         /// <param name="token">The <see cref="T:System.Threading.CancellationToken" /> that notifies when the task should be canceled.</param>
         /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
-        public async Task CloseAsync(CancellationToken token = default(CancellationToken))
+        public async Task CloseAsync(CancellationToken token = default)
         {
             await this.semaphore.WaitAsync(token).ConfigureAwait(false);
             try
@@ -150,7 +150,7 @@ namespace Workstation.ServiceModel.Ua
         /// </summary>
         /// <param name="token">The <see cref="T:System.Threading.CancellationToken" /> that notifies when the task should be canceled.</param>
         /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
-        public async Task OpenAsync(CancellationToken token = default(CancellationToken))
+        public async Task OpenAsync(CancellationToken token = default)
         {
             await this.semaphore.WaitAsync(token).ConfigureAwait(false);
             try
@@ -160,31 +160,6 @@ namespace Workstation.ServiceModel.Ua
             finally
             {
                 this.semaphore.Release();
-            }
-        }
-
-        /// <inheritdoc/>
-        void IDisposable.Dispose()
-        {
-            this.Dispose(true);
-        }
-
-        /// <summary>
-        /// Release unmanaged resources
-        /// </summary>
-        /// <param name="disposing">True when disposing, otherwise finalizing.</param>
-        protected virtual void Dispose(bool disposing)
-        {
-            if (disposing)
-            {
-                try
-                {
-                    this.CloseAsync().Wait(5000);
-                }
-                catch
-                {
-                    this.logger?.LogError("Error closing channel");
-                }
             }
         }
     }

--- a/UaClient/ServiceModel/Ua/UserNameIdentity.cs
+++ b/UaClient/ServiceModel/Ua/UserNameIdentity.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright (c) Converter Systems LLC. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-#nullable enable
-
 namespace Workstation.ServiceModel.Ua
 {
     public class UserNameIdentity : IUserIdentity

--- a/UaClient/ServiceModel/Ua/Variant.cs
+++ b/UaClient/ServiceModel/Ua/Variant.cs
@@ -42,7 +42,7 @@ namespace Workstation.ServiceModel.Ua
         DiagnosticInfo = 25,
     }
 
-    public struct Variant
+    public readonly struct Variant
     {
         public static readonly Variant Null = default(Variant);
 

--- a/UaClient/ServiceModel/Ua/Variant.cs
+++ b/UaClient/ServiceModel/Ua/Variant.cs
@@ -8,8 +8,6 @@ using System.Linq;
 using System.Reflection;
 using System.Xml.Linq;
 
-#nullable enable
-
 namespace Workstation.ServiceModel.Ua
 {
     public enum VariantType

--- a/UaClient/ServiceModel/Ua/VariantExtensions.cs
+++ b/UaClient/ServiceModel/Ua/VariantExtensions.cs
@@ -6,8 +6,6 @@ using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Reflection;
 
-#nullable enable
-
 namespace Workstation.ServiceModel.Ua
 {
     public static class VariantExtensions

--- a/UaClient/ServiceModel/Ua/ViewServiceSet.cs
+++ b/UaClient/ServiceModel/Ua/ViewServiceSet.cs
@@ -2,8 +2,8 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
+using System.Threading;
 using System.Threading.Tasks;
-using Workstation.ServiceModel.Ua.Channels;
 
 #nullable enable
 
@@ -17,14 +17,14 @@ namespace Workstation.ServiceModel.Ua
         /// <param name="channel">A instance of <see cref="IRequestChannel"/>.</param>
         /// <param name="request">A <see cref="BrowseRequest"/>.</param>
         /// <returns>A <see cref="Task"/> representing the asynchronous operation that returns a <see cref="BrowseResponse"/>.</returns>
-        public static async Task<BrowseResponse> BrowseAsync(this IRequestChannel channel, BrowseRequest request)
+        public static async Task<BrowseResponse> BrowseAsync(this IRequestChannel channel, BrowseRequest request, CancellationToken token = default)
         {
             if (request == null)
             {
                 throw new ArgumentNullException(nameof(request));
             }
 
-            return (BrowseResponse)await channel.RequestAsync(request).ConfigureAwait(false);
+            return (BrowseResponse)await channel.RequestAsync(request, token).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -33,14 +33,14 @@ namespace Workstation.ServiceModel.Ua
         /// <param name="channel">A instance of <see cref="IRequestChannel"/>.</param>
         /// <param name="request">A <see cref="BrowseNextRequest"/>.</param>
         /// <returns>A <see cref="Task"/> representing the asynchronous operation that returns a <see cref="BrowseNextResponse"/>.</returns>
-        public static async Task<BrowseNextResponse> BrowseNextAsync(this IRequestChannel channel, BrowseNextRequest request)
+        public static async Task<BrowseNextResponse> BrowseNextAsync(this IRequestChannel channel, BrowseNextRequest request, CancellationToken token = default)
         {
             if (request == null)
             {
                 throw new ArgumentNullException(nameof(request));
             }
 
-            return (BrowseNextResponse)await channel.RequestAsync(request).ConfigureAwait(false);
+            return (BrowseNextResponse)await channel.RequestAsync(request, token).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -49,14 +49,14 @@ namespace Workstation.ServiceModel.Ua
         /// <param name="channel">A instance of <see cref="IRequestChannel"/>.</param>
         /// <param name="request">A <see cref="TranslateBrowsePathsToNodeIdsRequest"/>.</param>
         /// <returns>A <see cref="Task"/> representing the asynchronous operation that returns a <see cref="TranslateBrowsePathsToNodeIdsResponse"/>.</returns>
-        public static async Task<TranslateBrowsePathsToNodeIdsResponse> TranslateBrowsePathsToNodeIdsAsync(this IRequestChannel channel, TranslateBrowsePathsToNodeIdsRequest request)
+        public static async Task<TranslateBrowsePathsToNodeIdsResponse> TranslateBrowsePathsToNodeIdsAsync(this IRequestChannel channel, TranslateBrowsePathsToNodeIdsRequest request, CancellationToken token = default)
         {
             if (request == null)
             {
                 throw new ArgumentNullException(nameof(request));
             }
 
-            return (TranslateBrowsePathsToNodeIdsResponse)await channel.RequestAsync(request).ConfigureAwait(false);
+            return (TranslateBrowsePathsToNodeIdsResponse)await channel.RequestAsync(request, token).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -65,14 +65,14 @@ namespace Workstation.ServiceModel.Ua
         /// <param name="channel">A instance of <see cref="IRequestChannel"/>.</param>
         /// <param name="request">A <see cref="RegisterNodesRequest"/>.</param>
         /// <returns>A <see cref="Task"/> representing the asynchronous operation that returns a <see cref="RegisterNodesResponse"/>.</returns>
-        public static async Task<RegisterNodesResponse> RegisterNodesAsync(this IRequestChannel channel, RegisterNodesRequest request)
+        public static async Task<RegisterNodesResponse> RegisterNodesAsync(this IRequestChannel channel, RegisterNodesRequest request, CancellationToken token = default)
         {
             if (request == null)
             {
                 throw new ArgumentNullException(nameof(request));
             }
 
-            return (RegisterNodesResponse)await channel.RequestAsync(request).ConfigureAwait(false);
+            return (RegisterNodesResponse)await channel.RequestAsync(request, token).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -81,14 +81,14 @@ namespace Workstation.ServiceModel.Ua
         /// <param name="channel">A instance of <see cref="IRequestChannel"/>.</param>
         /// <param name="request">A <see cref="UnregisterNodesRequest"/>.</param>
         /// <returns>A <see cref="Task"/> representing the asynchronous operation that returns a <see cref="UnregisterNodesResponse"/>.</returns>
-        public static async Task<UnregisterNodesResponse> UnregisterNodesAsync(this IRequestChannel channel, UnregisterNodesRequest request)
+        public static async Task<UnregisterNodesResponse> UnregisterNodesAsync(this IRequestChannel channel, UnregisterNodesRequest request, CancellationToken token = default)
         {
             if (request == null)
             {
                 throw new ArgumentNullException(nameof(request));
             }
 
-            return (UnregisterNodesResponse)await channel.RequestAsync(request).ConfigureAwait(false);
+            return (UnregisterNodesResponse)await channel.RequestAsync(request, token).ConfigureAwait(false);
         }
     }
 }

--- a/UaClient/ServiceModel/Ua/ViewServiceSet.cs
+++ b/UaClient/ServiceModel/Ua/ViewServiceSet.cs
@@ -5,8 +5,6 @@ using System;
 using System.Threading;
 using System.Threading.Tasks;
 
-#nullable enable
-
 namespace Workstation.ServiceModel.Ua
 {
     public static class ViewServiceSet

--- a/UaClient/ServiceModel/Ua/X509Identity.cs
+++ b/UaClient/ServiceModel/Ua/X509Identity.cs
@@ -14,8 +14,6 @@ using Org.BouncyCastle.X509;
 using Org.BouncyCastle.X509.Extension;
 using Org.BouncyCastle.X509.Store;
 
-#nullable enable
-
 namespace Workstation.ServiceModel.Ua
 {
     public class X509Identity : IUserIdentity

--- a/UaClient/ServiceModel/Ua/XmlEncodingIdAttribute.cs
+++ b/UaClient/ServiceModel/Ua/XmlEncodingIdAttribute.cs
@@ -3,8 +3,6 @@
 
 using System;
 
-#nullable enable
-
 namespace Workstation.ServiceModel.Ua
 {
     /// <summary>

--- a/UaClient/Workstation.UaClient.csproj
+++ b/UaClient/Workstation.UaClient.csproj
@@ -23,6 +23,7 @@
     <GenerateDocumentationFile Condition=" '$(Configuration)' == 'Release' ">true</GenerateDocumentationFile>
     <PackageLicenseFile>LICENSE.txt</PackageLicenseFile>
     <LangVersion>8.0</LangVersion>
+    <Nullable>enable</Nullable>
   </PropertyGroup>
 
   <ItemGroup>

--- a/UaClient/Workstation.UaClient.csproj
+++ b/UaClient/Workstation.UaClient.csproj
@@ -4,7 +4,7 @@
     <TargetFrameworks>netstandard2.0;netcoreapp3.0</TargetFrameworks>
     <AssemblyName>Workstation.UaClient</AssemblyName>
     <RootNamespace>Workstation</RootNamespace>
-    <Version>2.5.0</Version>
+    <Version>2.5.2</Version>
     <Authors>Andrew Cullen</Authors>
     <Company>Converter Systems LLC</Company>
     <PackageProjectUrl>https://github.com/convertersystems/opc-ua-client</PackageProjectUrl>
@@ -12,11 +12,11 @@
     <Description>A library to browse, read, write and subscribe to the live data published by the OPC UA servers on your network.</Description>
     <PackageTags>opc, opc-ua, iiot</PackageTags>
     <RepositoryUrl>https://github.com/convertersystems/opc-ua-client</RepositoryUrl>
-    <Copyright>Copyright ©  2019 Converter Systems LLC.</Copyright>
-    <AssemblyVersion>2.5.0.0</AssemblyVersion>
+    <Copyright>Copyright ©  2020 Converter Systems LLC.</Copyright>
+    <AssemblyVersion>2.5.2.0</AssemblyVersion>
     <AssemblyTitle>Workstation.UaClient ($(TargetFramework))</AssemblyTitle>
     <GeneratePackageOnBuild>False</GeneratePackageOnBuild>
-    <FileVersion>2.5.0.0</FileVersion>
+    <FileVersion>2.5.2.0</FileVersion>
     <SignAssembly>True</SignAssembly>
     <AssemblyOriginatorKeyFile>Key.snk</AssemblyOriginatorKeyFile>
     <IncludeSymbols>true</IncludeSymbols>


### PR DESCRIPTION
In this PR I opt-in the nullable reference types on the project level and removed the single, file-scoped `#nullable` directives. Futhermore, I merged the master into the feature branch. The whole project compiles now without any (NRT) warning.

The only thing that is missing is to figure out if there needs to be any changes to the packaging. Ideally, we have a mutli target nuget package for the target netstandard2.0 and dotnetcore3.0. So that on the one hand a user using dotnetcore3.0 or higher can benefit from the new annotations, and on the other hand a NET framework user can still use the package as he/she used to do. I would like to ask you, if you can try that out.

In #119 we planed to put the changes into a 3.0 release. Now, I think this is not neccessary. There is no breaking change. A 2.6 release would be probably sufficient.