### PR TITLE
[WIP] Run integration the in the CI workflow

### DIFF
--- a/.github/workflows/unittests.yml
+++ b/.github/workflows/unittests.yml
@@ -21,5 +21,20 @@ jobs:
       run: rsync -a ${DOTNET_ROOT/3.0.100/2.2.108}/* $DOTNET_ROOT/
     - name: Build with dotnet
       run: dotnet build --configuration Release
-    - name: Run unit tests
-      run: dotnet test --filter "FullyQualifiedName~UnitTests" 
+    - name: Download test server
+      uses: Legion2/download-release-action@v2.1.0
+      with:
+        repository: quinmars/UaTestServer
+        tag: 'rel/v1.0.1'
+        path: testserver
+        file: UaTestServer-1.0.1.zip
+    - run: |
+          ls testserver
+          unzip testserver/UaTestServer-1.0.1.zip -d uatestserver
+          ls testserver
+    - name: Run test server and tests
+      run: |
+          cd uatestserver
+          dotnet UaTestServer.dll &
+          cd ..
+          dotnet test 

--- a/UaClient.UnitTests/IntegrationTests/IntegrationTests.cs
+++ b/UaClient.UnitTests/IntegrationTests/IntegrationTests.cs
@@ -327,6 +327,7 @@ namespace Workstation.UaClient.IntegrationTests
         /// Only run this test with a running opc test server.
         /// </summary>
         /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
+#if false
         [MemberData(nameof(AllTestEndpointData))]
         [Theory]
         public async Task VectorAdd(TestEndpoint endpoint)
@@ -362,6 +363,7 @@ namespace Workstation.UaClient.IntegrationTests
             result.Z
                 .Should().Be(6.0);
         }
+#endif
 
         [DataTypeId("nsu=http://www.unifiedautomation.com/DemoServer/;i=3002")]
         [BinaryEncodingId("nsu=http://www.unifiedautomation.com/DemoServer/;i=5054")]
@@ -395,6 +397,7 @@ namespace Workstation.UaClient.IntegrationTests
         /// Only run this test with a running opc test server.
         /// </summary>
         /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
+#if false
         [Fact]
         public async Task ReadHistorical()
         {
@@ -467,7 +470,7 @@ namespace Workstation.UaClient.IntegrationTests
             logger.LogInformation($"Closing session '{channel.SessionId}'.");
             await channel.CloseAsync();
         }
-
+#endif
         /// <summary>
         /// Tests connecting to endpoint and creating a subscription based view model.
         /// Only run this test with a running opc test server.
@@ -639,6 +642,7 @@ namespace Workstation.UaClient.IntegrationTests
         /// Tests result of transfer subscription from channel1 to channel2.
         /// </summary>
         /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
+#if false
         [MemberData(nameof(UserIdentities))]
         [Theory]
         public async Task TransferSubscription(IUserIdentity identity)
@@ -732,6 +736,7 @@ namespace Workstation.UaClient.IntegrationTests
             logger.LogInformation($"Closing session '{channel2.SessionId}'.");
             await channel2.CloseAsync();
         }
+#endif
 
     }
 }

--- a/UaClient.UnitTests/TestServer/ITestServer.cs
+++ b/UaClient.UnitTests/TestServer/ITestServer.cs
@@ -1,0 +1,14 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using Workstation.ServiceModel.Ua;
+
+namespace Workstation.UaClient.TestServer
+{
+    interface ITestServer
+    {
+        string EndpointUrl { get; }
+        TestEndpoint[] TestEndpoints { get; }
+        IUserIdentity[] UserIdentities { get; }
+    }
+}

--- a/UaClient.UnitTests/TestServer/TestEndpoint.cs
+++ b/UaClient.UnitTests/TestServer/TestEndpoint.cs
@@ -1,0 +1,22 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using Workstation.ServiceModel.Ua;
+
+namespace Workstation.UaClient.TestServer
+{
+    public class TestEndpoint
+    {
+        public string EndpointUrl { get; set; }
+        public string SecurityPolicyUri { get; set; }
+        public MessageSecurityMode SecurityMode { get; set; }
+        public IUserIdentity UserIdentity { get; set; }
+
+        public EndpointDescription EndpointDescription => new EndpointDescription
+        {
+            EndpointUrl = this.EndpointUrl,
+            SecurityPolicyUri = this.SecurityPolicyUri,
+            SecurityMode = this.SecurityMode,
+        };
+}
+}

--- a/UaClient.UnitTests/TestServer/UaTestServer.cs
+++ b/UaClient.UnitTests/TestServer/UaTestServer.cs
@@ -1,0 +1,222 @@
+﻿using Org.BouncyCastle.Crypto;
+using Org.BouncyCastle.Crypto.Parameters;
+using Org.BouncyCastle.OpenSsl;
+using Org.BouncyCastle.X509;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+using Workstation.ServiceModel.Ua;
+
+namespace Workstation.UaClient.TestServer
+{
+    public class UaTestServer : ITestServer
+    {
+        public string EndpointUrl => "opc.tcp://localhost:62541/UaTestServer";
+        public TestEndpoint[] TestEndpoints { get; }
+        public IUserIdentity[] UserIdentities { get; }
+
+        public UaTestServer(string pkiPath)
+        {
+            var x509Identity = default(X509Identity);
+            var userNameIdentity = new UserNameIdentity("user1", "password");
+
+            // read x509Identity
+            var userCert = default(X509Certificate);
+            var userKey = default(RsaKeyParameters);
+
+            var certParser = new X509CertificateParser();
+            var userCertInfo = new FileInfo(Path.Combine(pkiPath, "user", "certs", "ctt_usrT.der"));
+            if (userCertInfo.Exists)
+            {
+                using (var crtStream = userCertInfo.OpenRead())
+                {
+                    var c = certParser.ReadCertificate(crtStream);
+                    if (c != null)
+                    {
+                        userCert = c;
+                    }
+                }
+            }
+            var userKeyInfo = new FileInfo(Path.Combine(pkiPath, "user", "private", "ctt_usrT.pem"));
+            if (userKeyInfo.Exists)
+            {
+                using (var keyStream = new StreamReader(userKeyInfo.OpenRead()))
+                {
+                    var keyReader = new PemReader(keyStream);
+                    var keyPair = keyReader.ReadObject() as AsymmetricCipherKeyPair;
+                    if (keyPair != null)
+                    {
+                        userKey = keyPair.Private as RsaKeyParameters;
+                    }
+                }
+            }
+            
+            if (userCert != null && userKey != null)
+            {
+                x509Identity = new X509Identity(userCert, userKey);
+            }
+            
+            this.UserIdentities = new IUserIdentity[] 
+            {
+                new AnonymousIdentity(),
+                userNameIdentity,
+                x509Identity
+            }
+            .Where(x => x != null)
+            .ToArray();
+
+            this.TestEndpoints = new[]
+            {
+                new TestEndpoint
+                {
+                    EndpointUrl = EndpointUrl,
+                    SecurityPolicyUri =  SecurityPolicyUris.None,
+                    SecurityMode = MessageSecurityMode.None,
+                    UserIdentity = new AnonymousIdentity()
+                },
+                new TestEndpoint
+                {
+                    EndpointUrl = EndpointUrl,
+                    SecurityPolicyUri =  SecurityPolicyUris.None,
+                    SecurityMode = MessageSecurityMode.None,
+                    UserIdentity = userNameIdentity
+                },
+                new TestEndpoint
+                {
+                    EndpointUrl = EndpointUrl,
+                    SecurityPolicyUri =  SecurityPolicyUris.None,
+                    SecurityMode = MessageSecurityMode.None,
+                    UserIdentity = x509Identity
+                },
+                new TestEndpoint
+                {
+                    EndpointUrl = EndpointUrl,
+                    SecurityPolicyUri = SecurityPolicyUris.Basic256Sha256,
+                    SecurityMode = MessageSecurityMode.Sign,
+                    UserIdentity = new AnonymousIdentity()
+                },
+                new TestEndpoint
+                {
+                    EndpointUrl = EndpointUrl,
+                    SecurityPolicyUri = SecurityPolicyUris.Basic256Sha256,
+                    SecurityMode = MessageSecurityMode.Sign,
+                    UserIdentity = userNameIdentity
+                },
+                new TestEndpoint
+                {
+                    EndpointUrl = EndpointUrl,
+                    SecurityPolicyUri = SecurityPolicyUris.Basic256Sha256,
+                    SecurityMode = MessageSecurityMode.Sign,
+                    UserIdentity = x509Identity
+                },
+                new TestEndpoint
+                {
+                    EndpointUrl = EndpointUrl,
+                    SecurityPolicyUri = SecurityPolicyUris.Aes128_Sha256_RsaOaep,
+                    SecurityMode = MessageSecurityMode.Sign,
+                    UserIdentity = new AnonymousIdentity()
+                },
+                new TestEndpoint
+                {
+                    EndpointUrl = EndpointUrl,
+                    SecurityPolicyUri = SecurityPolicyUris.Aes128_Sha256_RsaOaep,
+                    SecurityMode = MessageSecurityMode.Sign,
+                    UserIdentity = userNameIdentity
+                },
+                new TestEndpoint
+                {
+                    EndpointUrl = EndpointUrl,
+                    SecurityPolicyUri = SecurityPolicyUris.Aes128_Sha256_RsaOaep,
+                    SecurityMode = MessageSecurityMode.Sign,
+                    UserIdentity = x509Identity
+                },
+                new TestEndpoint
+                {
+                    EndpointUrl = EndpointUrl,
+                    SecurityPolicyUri = SecurityPolicyUris.Aes256_Sha256_RsaPss,
+                    SecurityMode = MessageSecurityMode.Sign,
+                    UserIdentity = new AnonymousIdentity()
+                },
+                new TestEndpoint
+                {
+                    EndpointUrl = EndpointUrl,
+                    SecurityPolicyUri = SecurityPolicyUris.Aes256_Sha256_RsaPss,
+                    SecurityMode = MessageSecurityMode.Sign,
+                    UserIdentity = userNameIdentity
+                },
+                new TestEndpoint
+                {
+                    EndpointUrl = EndpointUrl,
+                    SecurityPolicyUri = SecurityPolicyUris.Aes256_Sha256_RsaPss,
+                    SecurityMode = MessageSecurityMode.Sign,
+                    UserIdentity = x509Identity
+                },
+                new TestEndpoint
+                {
+                    EndpointUrl = EndpointUrl,
+                    SecurityPolicyUri = SecurityPolicyUris.Basic256Sha256,
+                    SecurityMode = MessageSecurityMode.SignAndEncrypt,
+                    UserIdentity = new AnonymousIdentity()
+                },
+                new TestEndpoint
+                {
+                    EndpointUrl = EndpointUrl,
+                    SecurityPolicyUri = SecurityPolicyUris.Basic256Sha256,
+                    SecurityMode = MessageSecurityMode.SignAndEncrypt,
+                    UserIdentity = userNameIdentity
+                },
+                new TestEndpoint
+                {
+                    EndpointUrl = EndpointUrl,
+                    SecurityPolicyUri = SecurityPolicyUris.Basic256Sha256,
+                    SecurityMode = MessageSecurityMode.SignAndEncrypt,
+                    UserIdentity = x509Identity
+                },
+                new TestEndpoint
+                {
+                    EndpointUrl = EndpointUrl,
+                    SecurityPolicyUri = SecurityPolicyUris.Aes128_Sha256_RsaOaep,
+                    SecurityMode = MessageSecurityMode.SignAndEncrypt,
+                    UserIdentity = new AnonymousIdentity()
+                },
+                new TestEndpoint
+                {
+                    EndpointUrl = EndpointUrl,
+                    SecurityPolicyUri = SecurityPolicyUris.Aes128_Sha256_RsaOaep,
+                    SecurityMode = MessageSecurityMode.SignAndEncrypt,
+                    UserIdentity = userNameIdentity
+                },
+                new TestEndpoint
+                {
+                    EndpointUrl = EndpointUrl,
+                    SecurityPolicyUri = SecurityPolicyUris.Aes128_Sha256_RsaOaep,
+                    SecurityMode = MessageSecurityMode.SignAndEncrypt,
+                    UserIdentity = x509Identity
+                },
+                new TestEndpoint
+                {
+                    EndpointUrl = EndpointUrl,
+                    SecurityPolicyUri = SecurityPolicyUris.Aes256_Sha256_RsaPss,
+                    SecurityMode = MessageSecurityMode.SignAndEncrypt,
+                    UserIdentity = new AnonymousIdentity()
+                },
+                new TestEndpoint
+                {
+                    EndpointUrl = EndpointUrl,
+                    SecurityPolicyUri = SecurityPolicyUris.Aes256_Sha256_RsaPss,
+                    SecurityMode = MessageSecurityMode.SignAndEncrypt,
+                    UserIdentity = userNameIdentity
+                },
+                new TestEndpoint
+                {
+                    EndpointUrl = EndpointUrl,
+                    SecurityPolicyUri = SecurityPolicyUris.Aes256_Sha256_RsaPss,
+                    SecurityMode = MessageSecurityMode.SignAndEncrypt,
+                    UserIdentity = x509Identity
+                },
+            };
+        }
+    }
+}

--- a/UaClient.UnitTests/TestServer/UnifiedAutomation.cs
+++ b/UaClient.UnitTests/TestServer/UnifiedAutomation.cs
@@ -1,0 +1,214 @@
+﻿using Org.BouncyCastle.Crypto;
+using Org.BouncyCastle.Crypto.Parameters;
+using Org.BouncyCastle.OpenSsl;
+using Org.BouncyCastle.X509;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Text;
+using Workstation.ServiceModel.Ua;
+
+namespace Workstation.UaClient.TestServer
+{
+    public class UnifiedAutomation : ITestServer
+    {
+        public string EndpointUrl => "opc.tcp://localhost:48010";
+        public TestEndpoint[] TestEndpoints { get; }
+        public IUserIdentity[] UserIdentities { get; }
+
+        public UnifiedAutomation(string pkiPath)
+        {
+            var x509Identity = default(X509Identity);
+            var userNameIdentity = new UserNameIdentity("root", "secret");
+
+            // read x509Identity
+            var userCert = default(X509Certificate);
+            var userKey = default(RsaKeyParameters);
+
+            var certParser = new X509CertificateParser();
+            var userCertInfo = new FileInfo(Path.Combine(pkiPath, "user", "certs", "ctt_usrT.der"));
+            if (userCertInfo.Exists)
+            {
+                using (var crtStream = userCertInfo.OpenRead())
+                {
+                    var c = certParser.ReadCertificate(crtStream);
+                    if (c != null)
+                    {
+                        userCert = c;
+                    }
+                }
+            }
+            var userKeyInfo = new FileInfo(Path.Combine(pkiPath, "user", "private", "ctt_usrT.pem"));
+            if (userKeyInfo.Exists)
+            {
+                using (var keyStream = new StreamReader(userKeyInfo.OpenRead()))
+                {
+                    var keyReader = new PemReader(keyStream);
+                    var keyPair = keyReader.ReadObject() as AsymmetricCipherKeyPair;
+                    if (keyPair != null)
+                    {
+                        userKey = keyPair.Private as RsaKeyParameters;
+                    }
+                }
+            }
+            
+            if (userCert != null && userKey != null)
+            {
+                x509Identity = new X509Identity(userCert, userKey);
+            }
+
+            this.UserIdentities = new IUserIdentity[] { new AnonymousIdentity(), userNameIdentity, x509Identity };
+
+            this.TestEndpoints = new[]
+            {
+                new TestEndpoint
+                {
+                    EndpointUrl = EndpointUrl,
+                    SecurityPolicyUri =  SecurityPolicyUris.None,
+                    SecurityMode = MessageSecurityMode.None,
+                    UserIdentity = new AnonymousIdentity()
+                },
+                new TestEndpoint
+                {
+                    EndpointUrl = EndpointUrl,
+                    SecurityPolicyUri =  SecurityPolicyUris.None,
+                    SecurityMode = MessageSecurityMode.None,
+                    UserIdentity = userNameIdentity
+                },
+                new TestEndpoint
+                {
+                    EndpointUrl = EndpointUrl,
+                    SecurityPolicyUri =  SecurityPolicyUris.None,
+                    SecurityMode = MessageSecurityMode.None,
+                    UserIdentity = x509Identity
+                },
+                new TestEndpoint
+                {
+                    EndpointUrl = EndpointUrl,
+                    SecurityPolicyUri = SecurityPolicyUris.Basic256Sha256,
+                    SecurityMode = MessageSecurityMode.Sign,
+                    UserIdentity = new AnonymousIdentity()
+                },
+                new TestEndpoint
+                {
+                    EndpointUrl = EndpointUrl,
+                    SecurityPolicyUri = SecurityPolicyUris.Basic256Sha256,
+                    SecurityMode = MessageSecurityMode.Sign,
+                    UserIdentity = userNameIdentity
+                },
+                new TestEndpoint
+                {
+                    EndpointUrl = EndpointUrl,
+                    SecurityPolicyUri = SecurityPolicyUris.Basic256Sha256,
+                    SecurityMode = MessageSecurityMode.Sign,
+                    UserIdentity = x509Identity
+                },
+                new TestEndpoint
+                {
+                    EndpointUrl = EndpointUrl,
+                    SecurityPolicyUri = SecurityPolicyUris.Aes128_Sha256_RsaOaep,
+                    SecurityMode = MessageSecurityMode.Sign,
+                    UserIdentity = new AnonymousIdentity()
+                },
+                new TestEndpoint
+                {
+                    EndpointUrl = EndpointUrl,
+                    SecurityPolicyUri = SecurityPolicyUris.Aes128_Sha256_RsaOaep,
+                    SecurityMode = MessageSecurityMode.Sign,
+                    UserIdentity = userNameIdentity
+                },
+                new TestEndpoint
+                {
+                    EndpointUrl = EndpointUrl,
+                    SecurityPolicyUri = SecurityPolicyUris.Aes128_Sha256_RsaOaep,
+                    SecurityMode = MessageSecurityMode.Sign,
+                    UserIdentity = x509Identity
+                },
+                new TestEndpoint
+                {
+                    EndpointUrl = EndpointUrl,
+                    SecurityPolicyUri = SecurityPolicyUris.Aes256_Sha256_RsaPss,
+                    SecurityMode = MessageSecurityMode.Sign,
+                    UserIdentity = new AnonymousIdentity()
+                },
+                new TestEndpoint
+                {
+                    EndpointUrl = EndpointUrl,
+                    SecurityPolicyUri = SecurityPolicyUris.Aes256_Sha256_RsaPss,
+                    SecurityMode = MessageSecurityMode.Sign,
+                    UserIdentity = userNameIdentity
+                },
+                new TestEndpoint
+                {
+                    EndpointUrl = EndpointUrl,
+                    SecurityPolicyUri = SecurityPolicyUris.Aes256_Sha256_RsaPss,
+                    SecurityMode = MessageSecurityMode.Sign,
+                    UserIdentity = x509Identity
+                },
+                new TestEndpoint
+                {
+                    EndpointUrl = EndpointUrl,
+                    SecurityPolicyUri = SecurityPolicyUris.Basic256Sha256,
+                    SecurityMode = MessageSecurityMode.SignAndEncrypt,
+                    UserIdentity = new AnonymousIdentity()
+                },
+                new TestEndpoint
+                {
+                    EndpointUrl = EndpointUrl,
+                    SecurityPolicyUri = SecurityPolicyUris.Basic256Sha256,
+                    SecurityMode = MessageSecurityMode.SignAndEncrypt,
+                    UserIdentity = userNameIdentity
+                },
+                new TestEndpoint
+                {
+                    EndpointUrl = EndpointUrl,
+                    SecurityPolicyUri = SecurityPolicyUris.Basic256Sha256,
+                    SecurityMode = MessageSecurityMode.SignAndEncrypt,
+                    UserIdentity = x509Identity
+                },
+                new TestEndpoint
+                {
+                    EndpointUrl = EndpointUrl,
+                    SecurityPolicyUri = SecurityPolicyUris.Aes128_Sha256_RsaOaep,
+                    SecurityMode = MessageSecurityMode.SignAndEncrypt,
+                    UserIdentity = new AnonymousIdentity()
+                },
+                new TestEndpoint
+                {
+                    EndpointUrl = EndpointUrl,
+                    SecurityPolicyUri = SecurityPolicyUris.Aes128_Sha256_RsaOaep,
+                    SecurityMode = MessageSecurityMode.SignAndEncrypt,
+                    UserIdentity = userNameIdentity
+                },
+                new TestEndpoint
+                {
+                    EndpointUrl = EndpointUrl,
+                    SecurityPolicyUri = SecurityPolicyUris.Aes128_Sha256_RsaOaep,
+                    SecurityMode = MessageSecurityMode.SignAndEncrypt,
+                    UserIdentity = x509Identity
+                },
+                new TestEndpoint
+                {
+                    EndpointUrl = EndpointUrl,
+                    SecurityPolicyUri = SecurityPolicyUris.Aes256_Sha256_RsaPss,
+                    SecurityMode = MessageSecurityMode.SignAndEncrypt,
+                    UserIdentity = new AnonymousIdentity()
+                },
+                new TestEndpoint
+                {
+                    EndpointUrl = EndpointUrl,
+                    SecurityPolicyUri = SecurityPolicyUris.Aes256_Sha256_RsaPss,
+                    SecurityMode = MessageSecurityMode.SignAndEncrypt,
+                    UserIdentity = userNameIdentity
+                },
+                new TestEndpoint
+                {
+                    EndpointUrl = EndpointUrl,
+                    SecurityPolicyUri = SecurityPolicyUris.Aes256_Sha256_RsaPss,
+                    SecurityMode = MessageSecurityMode.SignAndEncrypt,
+                    UserIdentity = x509Identity
+                },
+            };
+        }
+    }
+}

--- a/UaClient.UnitTests/appSettings.json
+++ b/UaClient.UnitTests/appSettings.json
@@ -13,6 +13,13 @@
         "EndpointUrl": "opc.tcp://localhost:48010",
         "SecurityPolicyUri": "http://opcfoundation.org/UA/SecurityPolicy#None"
       }
+    },
+    {
+      "RequestedUrl": "opc.tcp://localhost:62541/UaTestServer",
+      "Endpoint": {
+        "EndpointUrl": "opc.tcp://localhost:62541/UaTestServer",
+        "SecurityPolicyUri": "http://opcfoundation.org/UA/SecurityPolicy#None"
+      }
     }
   ]
 }


### PR DESCRIPTION
As already mentioned in #111, I started to work on a fork of the UA OPC foundation reference server, that can be integrated into the CI workflow. This PR will use the UaTestServer. The combined code coverage of unit tests and integration tests is now at 79%! 

There are several other test code changes besides the UaTestServer integration in this PR. I changed for example `ConnnectToAllEndpoints` from activily polling the possible endpoints to hard coded endpoints. The reason is that you should not get the inputs to test from the subject to test. If for some reasons the discovery service returns an empty list, all test would pass falsely. I also removed many of the logging lines. I think they hide the important points, that are the test assertions. We should probably add more of them there. Since the data driven tests went so well I used that pattern for more of the test. I know that will increase the test time and some of the inputs are superfluous. We can reduce that with a reduced list later. The testing time is still acceptable (less than 10 minutes). One point was important for me: it should be easy to go back to the Unified Automation server, since it has more authority than "my" simple test server. The goal is that you have to only one line to change for switching from one test server to another.

There are some open points yet to solved or discuss:

1. I had to disable some integration tests because they do not work yet with UaTestServer. That are:
     - `ReadHistorical()`: The node id does not exist. But the test does currently not what it promise. 
     - `TransferSubscription()`: I guess that is simply not supported by the reference server application.
     - `VectorAdd()`: Here the function is not defined in the server.

  All those tests, do not increase the code coverage. They do more or less test the server and not the UaClient library.
  From a code coverage perspective, it'd be enough to test one kind of service request. The service sets and the data encoding
  are already covered by the unit tests. From my point of view `ReadHistorical()` can be removed, it was not functional before.
  While `TransferSubscription()` is a nice showcase, I think it is not worth the effort to implement it in the UaTestServer.
  The `VectorAdd()` test on the other hand would be good to keep, because of the additional type. That is a code branch, that is
  not covered at the moment. Althought, it is passing, I think we also could remove the `StackTest()`.

2. At the moment I pass an `EndpointDescription` with the URL, the security policy, and the security mode set, to the data driven test cases. The security mode isn't respected at the moment. The channel will always select SignedAndEncrypted. I don't know if this is intentional. So we have to either change the channel implementation or the test cases. Both ways shouldn't be to difficult.

3. I had to change the endpoint url of the `MyViewModel` subscription attribute. So it will not work for the Unified Automation server with this PR. I find the current situation a little bit inflexible. You can only change the endpoint url by code changes (I guess you could also override it by the appSettings.json file). But there is no way to change it dynamically by code. I propose to add an optional parameter to `SubscriptionBase` constructor to override the endpoint url by code.

4. I have recognized that you have some special code to test the `X509Identity`. I tried to preserve the code, but those code paths are not tested now, at least in an automatically setup up. I'm not that deep into the subject, do you see a way how we can automate that process? Maybe we can ship the certificates upfront or copy them from one point to another.

The integration tests are missing right now the fail paths. What happen, if you pass a non-existant server endpoint, if you choose a non-provided security policy, how does the client behave with an ill-behaving server? But I think those points should be tackled later.