### PR TITLE
Add "seealso" reference on the service set specification

### DIFF
--- a/UaClient/ServiceModel/Ua/AttributeServiceSet.cs
+++ b/UaClient/ServiceModel/Ua/AttributeServiceSet.cs
@@ -15,6 +15,7 @@ namespace Workstation.ServiceModel.Ua
         /// <param name="client">A instance of <see cref="IRequestChannel"/>.</param>
         /// <param name="request">A <see cref="ReadRequest"/>.</param>
         /// <returns>A <see cref="Task"/> representing the asynchronous operation that returns a <see cref="ReadResponse"/>.</returns>
+        /// <seealso href="https://reference.opcfoundation.org/v104/Core/docs/Part4/5.10.2/">OPC UA specification Part 4: Services, 5.10.2</seealso>
         public static async Task<ReadResponse> ReadAsync(this IRequestChannel client, ReadRequest request, CancellationToken token = default)
         {
             if (request == null)
@@ -31,6 +32,7 @@ namespace Workstation.ServiceModel.Ua
         /// <param name="client">A instance of <see cref="IRequestChannel"/>.</param>
         /// <param name="request">A <see cref="WriteRequest"/>.</param>
         /// <returns>A <see cref="Task"/> representing the asynchronous operation that returns a <see cref="WriteResponse"/>.</returns>
+        /// <seealso href="https://reference.opcfoundation.org/v104/Core/docs/Part4/5.10.4/">OPC UA specification Part 4: Services, 5.10.4</seealso>
         public static async Task<WriteResponse> WriteAsync(this IRequestChannel client, WriteRequest request, CancellationToken token = default)
         {
             if (request == null)
@@ -47,6 +49,7 @@ namespace Workstation.ServiceModel.Ua
         /// <param name="client">A instance of <see cref="IRequestChannel"/>.</param>
         /// <param name="request">A <see cref="HistoryReadRequest"/>.</param>
         /// <returns>A <see cref="Task"/> representing the asynchronous operation that returns a <see cref="HistoryReadResponse"/>.</returns>
+        /// <seealso href="https://reference.opcfoundation.org/v104/Core/docs/Part4/5.10.3/">OPC UA specification Part 4: Services, 5.10.3</seealso>
         public static async Task<HistoryReadResponse> HistoryReadAsync(this IRequestChannel client, HistoryReadRequest request, CancellationToken token = default)
         {
             if (request == null)
@@ -63,6 +66,7 @@ namespace Workstation.ServiceModel.Ua
         /// <param name="client">A instance of <see cref="IRequestChannel"/>.</param>
         /// <param name="request">A <see cref="HistoryUpdateRequest"/>.</param>
         /// <returns>A <see cref="Task"/> representing the asynchronous operation that returns a <see cref="HistoryUpdateResponse"/>.</returns>
+        /// <seealso href="https://reference.opcfoundation.org/v104/Core/docs/Part4/5.10.5/">OPC UA specification Part 4: Services, 5.10.5</seealso>
         public static async Task<HistoryUpdateResponse> HistoryUpdateAsync(this IRequestChannel client, HistoryUpdateRequest request, CancellationToken token = default)
         {
             if (request == null)

--- a/UaClient/ServiceModel/Ua/Channels/UaTcpSecureChannel.cs
+++ b/UaClient/ServiceModel/Ua/Channels/UaTcpSecureChannel.cs
@@ -671,6 +671,7 @@ namespace Workstation.ServiceModel.Ua.Channels
         }
 
         /// <inheritdoc/>
+        /// <seealso href="https://reference.opcfoundation.org/v104/Core/docs/Part4/5.5.2/">OPC UA specification Part 4: Services, 5.5.2</seealso>
         protected override async Task OnOpenAsync(CancellationToken token = default)
         {
             await base.OnOpenAsync(token).ConfigureAwait(false);
@@ -724,6 +725,7 @@ namespace Workstation.ServiceModel.Ua.Channels
         }
 
         /// <inheritdoc/>
+        /// <seealso href="https://reference.opcfoundation.org/v104/Core/docs/Part4/5.5.3/">OPC UA specification Part 4: Services, 5.5.3</seealso>
         protected override async Task OnCloseAsync(CancellationToken token = default)
         {
             try

--- a/UaClient/ServiceModel/Ua/MethodServiceSet.cs
+++ b/UaClient/ServiceModel/Ua/MethodServiceSet.cs
@@ -15,6 +15,7 @@ namespace Workstation.ServiceModel.Ua
         /// <param name="channel">A instance of <see cref="IRequestChannel"/>.</param>
         /// <param name="request">A <see cref="CallRequest"/>.</param>
         /// <returns>A <see cref="Task"/> representing the asynchronous operation that returns a <see cref="CallResponse"/>.</returns>
+        /// <seealso href="https://reference.opcfoundation.org/v104/Core/docs/Part4/5.11.2/">OPC UA specification Part 4: Services, 5.11.2</seealso>
         public static async Task<CallResponse> CallAsync(this IRequestChannel channel, CallRequest request, CancellationToken token = default)
         {
             if (request == null)

--- a/UaClient/ServiceModel/Ua/MonitoredItemServiceSet.cs
+++ b/UaClient/ServiceModel/Ua/MonitoredItemServiceSet.cs
@@ -15,6 +15,7 @@ namespace Workstation.ServiceModel.Ua
         /// <param name="channel">A instance of <see cref="IRequestChannel"/>.</param>
         /// <param name="request">A <see cref="CreateMonitoredItemsRequest"/>.</param>
         /// <returns>A <see cref="Task"/> representing the asynchronous operation that returns a <see cref="CreateMonitoredItemsResponse"/>.</returns>
+        /// <seealso href="https://reference.opcfoundation.org/v104/Core/docs/Part4/5.12.2/">OPC UA specification Part 4: Services, 5.12.2</seealso>
         public static async Task<CreateMonitoredItemsResponse> CreateMonitoredItemsAsync(this IRequestChannel channel, CreateMonitoredItemsRequest request, CancellationToken token = default)
         {
             if (request == null)
@@ -31,6 +32,7 @@ namespace Workstation.ServiceModel.Ua
         /// <param name="channel">A instance of <see cref="IRequestChannel"/>.</param>
         /// <param name="request">A <see cref="ModifyMonitoredItemsRequest"/>.</param>
         /// <returns>A <see cref="Task"/> representing the asynchronous operation that returns a <see cref="ModifyMonitoredItemsResponse"/>.</returns>
+        /// <seealso href="https://reference.opcfoundation.org/v104/Core/docs/Part4/5.12.3/">OPC UA specification Part 4: Services, 5.12.3</seealso>
         public static async Task<ModifyMonitoredItemsResponse> ModifyMonitoredItemsAsync(this IRequestChannel channel, ModifyMonitoredItemsRequest request, CancellationToken token = default)
         {
             if (request == null)
@@ -47,6 +49,7 @@ namespace Workstation.ServiceModel.Ua
         /// <param name="channel">A instance of <see cref="IRequestChannel"/>.</param>
         /// <param name="request">A <see cref="SetMonitoringModeRequest"/>.</param>
         /// <returns>A <see cref="Task"/> representing the asynchronous operation that returns a <see cref="SetMonitoringModeResponse"/>.</returns>
+        /// <seealso href="https://reference.opcfoundation.org/v104/Core/docs/Part4/5.12.4/">OPC UA specification Part 4: Services, 5.12.4</seealso>
         public static async Task<SetMonitoringModeResponse> SetMonitoringModeAsync(this IRequestChannel channel, SetMonitoringModeRequest request, CancellationToken token = default)
         {
             if (request == null)
@@ -63,6 +66,7 @@ namespace Workstation.ServiceModel.Ua
         /// <param name="channel">A instance of <see cref="IRequestChannel"/>.</param>
         /// <param name="request">A <see cref="SetTriggeringRequest"/>.</param>
         /// <returns>A <see cref="Task"/> representing the asynchronous operation that returns a <see cref="SetTriggeringResponse"/>.</returns>
+        /// <seealso href="https://reference.opcfoundation.org/v104/Core/docs/Part4/5.12.5/">OPC UA specification Part 4: Services, 5.12.5</seealso>
         public static async Task<SetTriggeringResponse> SetTriggeringAsync(this IRequestChannel channel, SetTriggeringRequest request, CancellationToken token = default)
         {
             if (request == null)
@@ -79,6 +83,7 @@ namespace Workstation.ServiceModel.Ua
         /// <param name="channel">A instance of <see cref="IRequestChannel"/>.</param>
         /// <param name="request">A <see cref="DeleteMonitoredItemsRequest"/>.</param>
         /// <returns>A <see cref="Task"/> representing the asynchronous operation that returns a <see cref="DeleteMonitoredItemsResponse"/>.</returns>
+        /// <seealso href="https://reference.opcfoundation.org/v104/Core/docs/Part4/5.12.6/">OPC UA specification Part 4: Services, 5.12.6</seealso>
         public static async Task<DeleteMonitoredItemsResponse> DeleteMonitoredItemsAsync(this IRequestChannel channel, DeleteMonitoredItemsRequest request, CancellationToken token = default)
         {
             if (request == null)

--- a/UaClient/ServiceModel/Ua/NodeManagementServiceSet.cs
+++ b/UaClient/ServiceModel/Ua/NodeManagementServiceSet.cs
@@ -15,6 +15,7 @@ namespace Workstation.ServiceModel.Ua
         /// <param name="channel">A instance of <see cref="IRequestChannel"/>.</param>
         /// <param name="request">A <see cref="AddNodesRequest"/>.</param>
         /// <returns>A <see cref="Task"/> representing the asynchronous operation that returns a <see cref="AddNodesResponse"/>.</returns>
+        /// <seealso href="https://reference.opcfoundation.org/v104/Core/docs/Part4/5.7.2/">OPC UA specification Part 4: Services, 5.7.2</seealso>
         public static async Task<AddNodesResponse> AddNodesAsync(this IRequestChannel channel, AddNodesRequest request, CancellationToken token = default)
         {
             if (request == null)
@@ -31,6 +32,7 @@ namespace Workstation.ServiceModel.Ua
         /// <param name="channel">A instance of <see cref="IRequestChannel"/>.</param>
         /// <param name="request">A <see cref="AddReferencesRequest"/>.</param>
         /// <returns>A <see cref="Task"/> representing the asynchronous operation that returns a <see cref="AddReferencesResponse"/>.</returns>
+        /// <seealso href="https://reference.opcfoundation.org/v104/Core/docs/Part4/5.7.3/">OPC UA specification Part 4: Services, 5.7.3</seealso>
         public static async Task<AddReferencesResponse> AddReferencesAsync(this IRequestChannel channel, AddReferencesRequest request, CancellationToken token = default)
         {
             if (request == null)
@@ -47,6 +49,7 @@ namespace Workstation.ServiceModel.Ua
         /// <param name="channel">A instance of <see cref="IRequestChannel"/>.</param>
         /// <param name="request">A <see cref="DeleteNodesRequest"/>.</param>
         /// <returns>A <see cref="Task"/> representing the asynchronous operation that returns a <see cref="DeleteNodesResponse"/>.</returns>
+        /// <seealso href="https://reference.opcfoundation.org/v104/Core/docs/Part4/5.7.4/">OPC UA specification Part 4: Services, 5.7.4</seealso>
         public static async Task<DeleteNodesResponse> DeleteNodesAsync(this IRequestChannel channel, DeleteNodesRequest request, CancellationToken token = default)
         {
             if (request == null)
@@ -63,6 +66,7 @@ namespace Workstation.ServiceModel.Ua
         /// <param name="channel">A instance of <see cref="IRequestChannel"/>.</param>
         /// <param name="request">A <see cref="DeleteReferencesRequest"/>.</param>
         /// <returns>A <see cref="Task"/> representing the asynchronous operation that returns a <see cref="DeleteReferencesResponse"/>.</returns>
+        /// <seealso href="https://reference.opcfoundation.org/v104/Core/docs/Part4/5.7.5/">OPC UA specification Part 4: Services, 5.7.5</seealso>
         public static async Task<DeleteReferencesResponse> DeleteReferencesAsync(this IRequestChannel channel, DeleteReferencesRequest request, CancellationToken token = default)
         {
             if (request == null)

--- a/UaClient/ServiceModel/Ua/QueryServiceSet.cs
+++ b/UaClient/ServiceModel/Ua/QueryServiceSet.cs
@@ -15,6 +15,7 @@ namespace Workstation.ServiceModel.Ua
         /// <param name="channel">A instance of <see cref="IRequestChannel"/>.</param>
         /// <param name="request">A <see cref="QueryFirstRequest"/>.</param>
         /// <returns>A <see cref="Task"/> representing the asynchronous operation that returns a <see cref="QueryFirstResponse"/>.</returns>
+        /// <seealso href="https://reference.opcfoundation.org/v104/Core/docs/Part4/5.9.3/">OPC UA specification Part 4: Services, 5.9.3</seealso>
         public static async Task<QueryFirstResponse> QueryFirstAsync(this IRequestChannel channel, QueryFirstRequest request, CancellationToken token = default)
         {
             if (request == null)
@@ -31,6 +32,7 @@ namespace Workstation.ServiceModel.Ua
         /// <param name="channel">A instance of <see cref="IRequestChannel"/>.</param>
         /// <param name="request">A <see cref="QueryNextRequest"/>.</param>
         /// <returns>A <see cref="Task"/> representing the asynchronous operation that returns a <see cref="QueryNextResponse"/>.</returns>
+        /// <seealso href="https://reference.opcfoundation.org/v104/Core/docs/Part4/5.9.4/">OPC UA specification Part 4: Services, 5.9.4</seealso>
         public static async Task<QueryNextResponse> QueryNextAsync(this IRequestChannel channel, QueryNextRequest request, CancellationToken token = default)
         {
             if (request == null)

--- a/UaClient/ServiceModel/Ua/SessionServiceSet.cs
+++ b/UaClient/ServiceModel/Ua/SessionServiceSet.cs
@@ -15,6 +15,7 @@ namespace Workstation.ServiceModel.Ua
         /// <param name="channel">A instance of <see cref="IRequestChannel"/>.</param>
         /// <param name="request">A <see cref="CreateSessionRequest"/>.</param>
         /// <returns>A <see cref="Task"/> representing the asynchronous operation that returns a <see cref="CreateSessionResponse"/>.</returns>
+        /// <seealso href="https://reference.opcfoundation.org/v104/Core/docs/Part4/5.6.2/">OPC UA specification Part 4: Services, 5.6.2</seealso>
         internal static async Task<CreateSessionResponse> CreateSessionAsync(this IRequestChannel channel, CreateSessionRequest request, CancellationToken token = default)
         {
             if (request == null)
@@ -31,6 +32,7 @@ namespace Workstation.ServiceModel.Ua
         /// <param name="channel">A instance of <see cref="IRequestChannel"/>.</param>
         /// <param name="request">A <see cref="ActivateSessionRequest"/>.</param>
         /// <returns>A <see cref="Task"/> representing the asynchronous operation that returns a <see cref="ActivateSessionResponse"/>.</returns>
+        /// <seealso href="https://reference.opcfoundation.org/v104/Core/docs/Part4/5.6.3/">OPC UA specification Part 4: Services, 5.6.3</seealso>
         internal static async Task<ActivateSessionResponse> ActivateSessionAsync(this IRequestChannel channel, ActivateSessionRequest request, CancellationToken token = default)
         {
             if (request == null)
@@ -47,6 +49,7 @@ namespace Workstation.ServiceModel.Ua
         /// <param name="channel">A instance of <see cref="IRequestChannel"/>.</param>
         /// <param name="request">A <see cref="CloseSessionRequest"/>.</param>
         /// <returns>A <see cref="Task"/> representing the asynchronous operation that returns a <see cref="CloseSessionResponse"/>.</returns>
+        /// <seealso href="https://reference.opcfoundation.org/v104/Core/docs/Part4/5.6.4/">OPC UA specification Part 4: Services, 5.6.4</seealso>
         internal static async Task<CloseSessionResponse> CloseSessionAsync(this IRequestChannel channel, CloseSessionRequest request, CancellationToken token = default)
         {
             if (request == null)

--- a/UaClient/ServiceModel/Ua/SubscriptionServiceSet.cs
+++ b/UaClient/ServiceModel/Ua/SubscriptionServiceSet.cs
@@ -15,6 +15,7 @@ namespace Workstation.ServiceModel.Ua
         /// <param name="channel">A instance of <see cref="IRequestChannel"/>.</param>
         /// <param name="request">A <see cref="CreateSubscriptionRequest"/>.</param>
         /// <returns>A <see cref="Task"/> representing the asynchronous operation that returns a <see cref="CreateSubscriptionResponse"/>.</returns>
+        /// <seealso href="https://reference.opcfoundation.org/v104/Core/docs/Part4/5.13.2/">OPC UA specification Part 4: Services, 5.13.2</seealso>
         public static async Task<CreateSubscriptionResponse> CreateSubscriptionAsync(this IRequestChannel channel, CreateSubscriptionRequest request, CancellationToken token = default)
         {
             if (request == null)
@@ -31,6 +32,7 @@ namespace Workstation.ServiceModel.Ua
         /// <param name="channel">A instance of <see cref="IRequestChannel"/>.</param>
         /// <param name="request">A <see cref="ModifySubscriptionRequest"/>.</param>
         /// <returns>A <see cref="Task"/> representing the asynchronous operation that returns a <see cref="ModifySubscriptionResponse"/>.</returns>
+        /// <seealso href="https://reference.opcfoundation.org/v104/Core/docs/Part4/5.13.3/">OPC UA specification Part 4: Services, 5.13.3</seealso>
         public static async Task<ModifySubscriptionResponse> ModifySubscriptionAsync(this IRequestChannel channel, ModifySubscriptionRequest request, CancellationToken token = default)
         {
             if (request == null)
@@ -47,6 +49,7 @@ namespace Workstation.ServiceModel.Ua
         /// <param name="channel">A instance of <see cref="IRequestChannel"/>.</param>
         /// <param name="request">A <see cref="SetPublishingModeRequest"/>.</param>
         /// <returns>A <see cref="Task"/> representing the asynchronous operation that returns a <see cref="SetPublishingModeResponse"/>.</returns>
+        /// <seealso href="https://reference.opcfoundation.org/v104/Core/docs/Part4/5.13.4/">OPC UA specification Part 4: Services, 5.13.4</seealso>
         public static async Task<SetPublishingModeResponse> SetPublishingModeAsync(this IRequestChannel channel, SetPublishingModeRequest request, CancellationToken token = default)
         {
             if (request == null)
@@ -63,6 +66,7 @@ namespace Workstation.ServiceModel.Ua
         /// <param name="channel">A instance of <see cref="IRequestChannel"/>.</param>
         /// <param name="request">A <see cref="PublishRequest"/>.</param>
         /// <returns>A <see cref="Task"/> representing the asynchronous operation that returns a <see cref="PublishResponse"/>.</returns>
+        /// <seealso href="https://reference.opcfoundation.org/v104/Core/docs/Part4/5.13.5/">OPC UA specification Part 4: Services, 5.13.5</seealso>
         internal static async Task<PublishResponse> PublishAsync(this IRequestChannel channel, PublishRequest request, CancellationToken token = default)
         {
             if (request == null)
@@ -79,6 +83,7 @@ namespace Workstation.ServiceModel.Ua
         /// <param name="channel">A instance of <see cref="IRequestChannel"/>.</param>
         /// <param name="request">A <see cref="RepublishRequest"/>.</param>
         /// <returns>A <see cref="Task"/> representing the asynchronous operation that returns a <see cref="RepublishResponse"/>.</returns>
+        /// <seealso href="https://reference.opcfoundation.org/v104/Core/docs/Part4/5.13.6/">OPC UA specification Part 4: Services, 5.13.6</seealso>
         internal static async Task<RepublishResponse> RepublishAsync(this IRequestChannel channel, RepublishRequest request, CancellationToken token = default)
         {
             if (request == null)
@@ -95,6 +100,7 @@ namespace Workstation.ServiceModel.Ua
         /// <param name="channel">A instance of <see cref="IRequestChannel"/>.</param>
         /// <param name="request">A <see cref="TransferSubscriptionsRequest"/>.</param>
         /// <returns>A <see cref="Task"/> representing the asynchronous operation that returns a <see cref="TransferSubscriptionsResponse"/>.</returns>
+        /// <seealso href="https://reference.opcfoundation.org/v104/Core/docs/Part4/5.13.7/">OPC UA specification Part 4: Services, 5.13.7</seealso>
         public static async Task<TransferSubscriptionsResponse> TransferSubscriptionsAsync(this IRequestChannel channel, TransferSubscriptionsRequest request, CancellationToken token = default)
         {
             if (request == null)
@@ -111,6 +117,7 @@ namespace Workstation.ServiceModel.Ua
         /// <param name="channel">A instance of <see cref="IRequestChannel"/>.</param>
         /// <param name="request">A <see cref="DeleteSubscriptionsRequest"/>.</param>
         /// <returns>A <see cref="Task"/> representing the asynchronous operation that returns a <see cref="DeleteSubscriptionsResponse"/>.</returns>
+        /// <seealso href="https://reference.opcfoundation.org/v104/Core/docs/Part4/5.13.8/">OPC UA specification Part 4: Services, 5.13.8</seealso>
         public static async Task<DeleteSubscriptionsResponse> DeleteSubscriptionsAsync(this IRequestChannel channel, DeleteSubscriptionsRequest request, CancellationToken token = default)
         {
             if (request == null)

--- a/UaClient/ServiceModel/Ua/UaTcpDiscoveryService.cs
+++ b/UaClient/ServiceModel/Ua/UaTcpDiscoveryService.cs
@@ -40,6 +40,7 @@ namespace Workstation.ServiceModel.Ua
         /// </summary>
         /// <param name="request">a request.</param>
         /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
+        /// <seealso href="https://reference.opcfoundation.org/v104/Core/docs/Part4/5.4.2/">OPC UA specification Part 4: Services, 5.4.2</seealso>
         public static async Task<FindServersResponse> FindServersAsync(FindServersRequest request, ILoggerFactory? loggerFactory = null, UaApplicationOptions? options = null)
         {
             if (request == null)
@@ -77,6 +78,7 @@ namespace Workstation.ServiceModel.Ua
         /// <param name="loggerFactory">The logger factory.</param>
         /// <param name="options">The secure channel options.</param>
         /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
+        /// <seealso href="https://reference.opcfoundation.org/v104/Core/docs/Part4/5.4.4/">OPC UA specification Part 4: Services, 5.4.4</seealso>
         public static async Task<GetEndpointsResponse> GetEndpointsAsync(GetEndpointsRequest request, ILoggerFactory? loggerFactory = null, UaApplicationOptions? options = null)
         {
             if (request == null)

--- a/UaClient/ServiceModel/Ua/ViewServiceSet.cs
+++ b/UaClient/ServiceModel/Ua/ViewServiceSet.cs
@@ -15,6 +15,7 @@ namespace Workstation.ServiceModel.Ua
         /// <param name="channel">A instance of <see cref="IRequestChannel"/>.</param>
         /// <param name="request">A <see cref="BrowseRequest"/>.</param>
         /// <returns>A <see cref="Task"/> representing the asynchronous operation that returns a <see cref="BrowseResponse"/>.</returns>
+        /// <seealso href="https://reference.opcfoundation.org/v104/Core/docs/Part4/5.8.2/">OPC UA specification Part 4: Services, 5.8.2</seealso>
         public static async Task<BrowseResponse> BrowseAsync(this IRequestChannel channel, BrowseRequest request, CancellationToken token = default)
         {
             if (request == null)
@@ -31,6 +32,7 @@ namespace Workstation.ServiceModel.Ua
         /// <param name="channel">A instance of <see cref="IRequestChannel"/>.</param>
         /// <param name="request">A <see cref="BrowseNextRequest"/>.</param>
         /// <returns>A <see cref="Task"/> representing the asynchronous operation that returns a <see cref="BrowseNextResponse"/>.</returns>
+        /// <seealso href="https://reference.opcfoundation.org/v104/Core/docs/Part4/5.8.3/">OPC UA specification Part 4: Services, 5.8.3</seealso>
         public static async Task<BrowseNextResponse> BrowseNextAsync(this IRequestChannel channel, BrowseNextRequest request, CancellationToken token = default)
         {
             if (request == null)
@@ -47,6 +49,7 @@ namespace Workstation.ServiceModel.Ua
         /// <param name="channel">A instance of <see cref="IRequestChannel"/>.</param>
         /// <param name="request">A <see cref="TranslateBrowsePathsToNodeIdsRequest"/>.</param>
         /// <returns>A <see cref="Task"/> representing the asynchronous operation that returns a <see cref="TranslateBrowsePathsToNodeIdsResponse"/>.</returns>
+        /// <seealso href="https://reference.opcfoundation.org/v104/Core/docs/Part4/5.8.4/">OPC UA specification Part 4: Services, 5.8.4</seealso>
         public static async Task<TranslateBrowsePathsToNodeIdsResponse> TranslateBrowsePathsToNodeIdsAsync(this IRequestChannel channel, TranslateBrowsePathsToNodeIdsRequest request, CancellationToken token = default)
         {
             if (request == null)
@@ -63,6 +66,7 @@ namespace Workstation.ServiceModel.Ua
         /// <param name="channel">A instance of <see cref="IRequestChannel"/>.</param>
         /// <param name="request">A <see cref="RegisterNodesRequest"/>.</param>
         /// <returns>A <see cref="Task"/> representing the asynchronous operation that returns a <see cref="RegisterNodesResponse"/>.</returns>
+        /// <seealso href="https://reference.opcfoundation.org/v104/Core/docs/Part4/5.8.5/">OPC UA specification Part 4: Services, 5.8.5</seealso>
         public static async Task<RegisterNodesResponse> RegisterNodesAsync(this IRequestChannel channel, RegisterNodesRequest request, CancellationToken token = default)
         {
             if (request == null)
@@ -79,6 +83,7 @@ namespace Workstation.ServiceModel.Ua
         /// <param name="channel">A instance of <see cref="IRequestChannel"/>.</param>
         /// <param name="request">A <see cref="UnregisterNodesRequest"/>.</param>
         /// <returns>A <see cref="Task"/> representing the asynchronous operation that returns a <see cref="UnregisterNodesResponse"/>.</returns>
+        /// <seealso href="https://reference.opcfoundation.org/v104/Core/docs/Part4/5.8.6/">OPC UA specification Part 4: Services, 5.8.6</seealso>
         public static async Task<UnregisterNodesResponse> UnregisterNodesAsync(this IRequestChannel channel, UnregisterNodesRequest request, CancellationToken token = default)
         {
             if (request == null)


### PR DESCRIPTION
This PR adds a link to the corresponding specification section for the service sets.