### PR TITLE
Add the IOptionalFields interface

### DIFF
--- a/UaClient/ServiceModel/Ua/IOptionalFields.cs
+++ b/UaClient/ServiceModel/Ua/IOptionalFields.cs
@@ -1,0 +1,34 @@
+﻿// Copyright (c) Converter Systems LLC. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Workstation.ServiceModel.Ua
+{
+    /// <summary>
+    /// This interface should be implemented by every OPC Ua data type which is
+    /// derived from the OPC UA structure type and has one or more optional
+    /// fields.
+    /// 
+    /// Classes, that introduce optional fields first, should implement the
+    /// <see cref="OptionalFieldCount"/> property as a virtual property getter.
+    /// This allows derived classes to override this property, and thus
+    /// increase the number of optional fields. Classes should also provide
+    /// a `protected` setter method for the <see cref="EncodingMask"/>
+    /// property to enable derived classes to set the bits belonging to
+    /// its fields/properties.
+    /// </summary>
+    /// <seealso href="https://reference.opcfoundation.org/v104/Core/docs/Part6/5.2.7/">OPC UA specification Part 6: Mappings, 5.2.7</seealso>
+    /// <seealso href="https://reference.opcfoundation.org/v104/Core/docs/Part6/5.3.6/">OPC UA specification Part 6: Mappings, 5.3.6</seealso>
+    /// <seealso href="https://reference.opcfoundation.org/v104/Core/docs/Part6/5.4.7/">OPC UA specification Part 6: Mappings, 5.4.7</seealso>
+    public interface IOptionalFields
+    {
+        /// <summary>
+        /// Retrieves the count of optional fields, that is properities in dotnet.
+        /// </summary>
+        int OptionalFieldCount { get; }
+
+        /// <summary>
+        /// Retrieves the encoding mask.
+        /// </summary>
+        uint EncodingMask { get; }
+    }
+}


### PR DESCRIPTION
The `IOptionalFields` interface formalize the support for optional fields/properties. While it would be possible to implement optional fields in derived class with a naming convention only, having the interface makes it easier to test if the parent class already has optional fields; even over nodeset/assembly boundaries.  