### PR TITLE
StackProfile part 1: Tcp connection provider

### DIFF
--- a/UaClient/ServiceModel/Ua/Channels/UaClientConnection.cs
+++ b/UaClient/ServiceModel/Ua/Channels/UaClientConnection.cs
@@ -1,0 +1,211 @@
+﻿// Copyright (c) Converter Systems LLC. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Workstation.ServiceModel.Ua.Channels
+{
+    /// <summary>
+    /// The <see cref="ITransportConnection"/> interface implementation
+    /// for the OPC UA Connection Protocol.
+    /// </summary>
+    /// <seealso href="https://reference.opcfoundation.org/v104/Core/docs/Part6/7.1.1/">OPC UA specification Part 6: Mappings, 7.1.1</seealso>
+    public class UaClientConnection : ITransportConnection
+    {
+        private const int MinBufferSize = 8 * 1024;
+
+        /// <summary>
+        /// The stream to read from and write to.
+        /// </summary>
+        public Stream Stream { get; }
+
+        /// <summary>
+        /// The Uri of the connection.
+        /// </summary>
+        public Uri Uri { get; }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="UaClientConnection"/> class.
+        /// </summary>
+        /// <param name="stream">The stream.</param>
+        /// <param name="uri">The uri.</param>
+        public UaClientConnection(Stream stream, Uri uri)
+        {
+            Stream = stream;
+            Uri = uri;
+        }
+
+        /// <inheritdoc />
+#pragma warning disable CS1998
+        public async ValueTask DisposeAsync()
+#pragma warning restore CS1998
+        {
+#if NETCOREAPP3_0_OR_GREATER
+            await Stream.DisposeAsync();
+#else
+            Stream.Dispose();
+#endif
+        }
+
+        /// <summary>
+        /// Opens the connection. This includes the hello message handshake.
+        /// </summary>
+        /// <remakes>
+        /// The underlying network client is already opened before this class is
+        /// constructed. The
+        /// connection is closed with <see cref="IAsyncDisposable.DisposeAsync"/>
+        /// method.
+        /// </remakes>
+        /// <param name="protocolVersion">The protocol version.</param>
+        /// <param name="localOptions">The requested transport connection options.</param>
+        /// <param name="token">A cancellation token used to propagate notification that this operation should be canceled.</param>
+        /// <returns>The transport connection options to be used.</returns>
+        /// <seealso href="https://reference.opcfoundation.org/v104/Core/docs/Part6/7.1.2/">OPC UA specification Part 6: Mappings, 7.1.2</seealso>
+        public async Task<TransportConnectionOptions> OpenAsync(uint protocolVersion, TransportConnectionOptions localOptions, CancellationToken token)
+        {
+            var sendBuffer = new byte[MinBufferSize];
+            var receiveBuffer = new byte[MinBufferSize];
+
+            // send 'hello'.
+            int count;
+            var encoder = new BinaryEncoder(new MemoryStream(sendBuffer, 0, MinBufferSize, true, false));
+            try
+            {
+                encoder.WriteUInt32(null, UaTcpMessageTypes.HELF);
+                encoder.WriteUInt32(null, 0u);
+                encoder.WriteUInt32(null, protocolVersion);
+                encoder.WriteUInt32(null, localOptions.ReceiveBufferSize);
+                encoder.WriteUInt32(null, localOptions.SendBufferSize);
+                encoder.WriteUInt32(null, localOptions.MaxMessageSize);
+                encoder.WriteUInt32(null, localOptions.MaxChunkCount);
+                encoder.WriteString(null, Uri.ToString());
+                count = encoder.Position;
+                encoder.Position = 4;
+                encoder.WriteUInt32(null, (uint)count);
+                encoder.Position = count;
+
+                await SendAsync(sendBuffer, 0, count, token).ConfigureAwait(false);
+            }
+            finally
+            {
+                encoder.Dispose();
+            }
+
+            // receive response
+            count = await ReceiveAsync(receiveBuffer, 0, MinBufferSize, token).ConfigureAwait(false);
+            if (count == 0)
+            {
+                throw new ObjectDisposedException("socket");
+            }
+
+            // decode 'ack' or 'err'.
+            var decoder = new BinaryDecoder(new MemoryStream(receiveBuffer, 0, count, false, false));
+            try
+            {
+                var type = decoder.ReadUInt32(null);
+                var len = decoder.ReadUInt32(null);
+                if (type == UaTcpMessageTypes.ACKF)
+                {
+                    var remoteProtocolVersion = decoder.ReadUInt32(null);
+                    if (remoteProtocolVersion < protocolVersion)
+                    {
+                        throw new ServiceResultException(StatusCodes.BadProtocolVersionUnsupported);
+                    }
+
+                    var remoteOptions = new TransportConnectionOptions
+                    {
+                        SendBufferSize = decoder.ReadUInt32(null),
+                        ReceiveBufferSize = decoder.ReadUInt32(null),
+                        MaxMessageSize = decoder.ReadUInt32(null),
+                        MaxChunkCount = decoder.ReadUInt32(null)
+                    };
+
+                    return remoteOptions;
+                }
+                else if (type == UaTcpMessageTypes.ERRF)
+                {
+                    var statusCode = decoder.ReadUInt32(null);
+                    var message = decoder.ReadString(null);
+                    if (message != null)
+                    {
+                        throw new ServiceResultException(statusCode, message);
+                    }
+
+                    throw new ServiceResultException(statusCode);
+                }
+
+                throw new InvalidOperationException($"{nameof(UaClientConnection)}.{nameof(OpenAsync)} received unexpected message type.");
+            }
+            finally
+            {
+                decoder.Dispose();
+            }
+        }
+
+        /// <inheritdoc />
+        public async Task SendAsync(byte[] buffer, int offset, int count, CancellationToken token)
+        {
+            await Stream.WriteAsync(buffer, offset, count, token);
+        }
+
+        /// <inheritdoc />
+        public async Task<int> ReceiveAsync(byte[] buffer, int offset, int count, CancellationToken token)
+        {
+            int initialOffset = offset;
+            int maxCount = count;
+            int num;
+            count = 8;
+            while (count > 0)
+            {
+                try
+                {
+                    num = await Stream.ReadAsync(buffer, offset, count, token).ConfigureAwait(false);
+                }
+                catch (Exception)
+                {
+                    return 0;
+                }
+
+                if (num == 0)
+                {
+                    return 0;
+                }
+
+                offset += num;
+                count -= num;
+            }
+
+            var len = BitConverter.ToUInt32(buffer, 4);
+            if (len > maxCount)
+            {
+                throw new ServiceResultException(StatusCodes.BadResponseTooLarge);
+            }
+
+            count = (int)len - 8;
+            while (count > 0)
+            {
+                try
+                {
+                    num = await Stream.ReadAsync(buffer, offset, count, token).ConfigureAwait(false);
+                }
+                catch (Exception)
+                {
+                    return 0;
+                }
+
+                if (num == 0)
+                {
+                    return 0;
+                }
+
+                offset += num;
+                count -= num;
+            }
+
+            return offset - initialOffset;
+        }
+    }
+}

--- a/UaClient/ServiceModel/Ua/Channels/UaTcpConnectionProvider.cs
+++ b/UaClient/ServiceModel/Ua/Channels/UaTcpConnectionProvider.cs
@@ -1,0 +1,34 @@
+﻿// Copyright (c) Converter Systems LLC. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Net.Sockets;
+using System.Threading.Tasks;
+
+namespace Workstation.ServiceModel.Ua.Channels
+{
+    /// <summary>
+    /// The <see cref="ITransportConnectionProvider"/> interface implementation
+    /// for the OPC UA TCP transport protocol.
+    /// </summary>
+    /// <seealso href="https://reference.opcfoundation.org/v104/Core/docs/Part6/7.2/">OPC UA specification Part 6: Mappings, 7.2</seealso>
+    public class UaTcpConnectionProvider : ITransportConnectionProvider
+    {
+        private const int ConnectTimeout = 5000;
+
+        /// <inheritdoc />
+        public async Task<ITransportConnection> ConnectAsync(string connectionString)
+        {
+            var uri = new Uri(connectionString);
+            var client = new TcpClient
+            {
+                NoDelay = true
+            };
+
+            await client.ConnectAsync(uri.Host, uri.Port).TimeoutAfter(ConnectTimeout).ConfigureAwait(false);
+
+            // The stream will own the client and takes care on disposing/closing it
+            return new UaClientConnection(client.GetStream(), uri);
+        }
+    }
+}

--- a/UaClient/ServiceModel/Ua/ITransportConnection.cs
+++ b/UaClient/ServiceModel/Ua/ITransportConnection.cs
@@ -1,0 +1,51 @@
+﻿// Copyright (c) Converter Systems LLC. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Workstation.ServiceModel.Ua
+{
+    /// <summary>
+    /// The transport connection interface is used to support different
+    /// transport protocols in the transport channel implementation.
+    /// </summary>
+    /// <seealso href="https://reference.opcfoundation.org/v104/Core/docs/Part6/4/">OPC UA specification Part 6: Mappings, 4</seealso>
+    public interface ITransportConnection : IAsyncDisposable
+    {
+        /// <summary>
+        /// Opens the connection. This includes the hello message handshake.
+        /// </summary>
+        /// <remakes>
+        /// The real network may already be opened at a previous point. The
+        /// connection is closed with <see cref="IAsyncDisposable.DisposeAsync"/>
+        /// method.
+        /// </remakes>
+        /// <param name="protocolVersion">The protocol version.</param>
+        /// <param name="localOptions">The requested transport connection options.</param>
+        /// <param name="token">A cancellation token used to propagate notification that this operation should be canceled.</param>
+        /// <returns>The transport connection options to be used.</returns>
+        Task<TransportConnectionOptions> OpenAsync(uint protocolVersion, TransportConnectionOptions localOptions, CancellationToken token);
+
+        /// <summary>
+        /// Sends content from the buffer.
+        /// </summary>
+        /// <param name="buffer">The buffer.</param>
+        /// <param name="offset">The starting offset.</param>
+        /// <param name="count">The count of bytes to be send.</param>
+        /// <param name="token">A cancellation token used to propagate notification that this operation should be canceled.</param>
+        /// <returns>A task representing the asynchronous operation.</returns>
+        Task SendAsync(byte[] buffer, int offset, int count, CancellationToken token);
+        
+        /// <summary>
+        /// Receive content into the buffer.
+        /// </summary>
+        /// <param name="buffer">The buffer.</param>
+        /// <param name="offset">The starting offset.</param>
+        /// <param name="count">The count of bytes to be received.</param>
+        /// <param name="token">A cancellation token used to propagate notification that this operation should be canceled.</param>
+        /// <returns>A task representing the asynchronous operation.</returns>
+        Task<int> ReceiveAsync(byte[] buffer, int offset, int count, CancellationToken token);
+    }
+}

--- a/UaClient/ServiceModel/Ua/ITransportConnectionProvider.cs
+++ b/UaClient/ServiceModel/Ua/ITransportConnectionProvider.cs
@@ -1,0 +1,25 @@
+﻿// Copyright (c) Converter Systems LLC. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Threading.Tasks;
+
+namespace Workstation.ServiceModel.Ua
+{
+    /// <summary>
+    /// Provider interface for <see cref="ITransportConnection"/> instances.
+    /// </summary>
+    public interface ITransportConnectionProvider
+    {
+        /// <summary>
+        /// Creates a transport connection.
+        /// </summary>
+        /// <remarks>
+        /// The implementation can already open the bare network connection, or
+        /// defer this process to the <see cref="ITransportConnection.OpenAsync(uint, TransportConnectionOptions, System.Threading.CancellationToken)"/>
+        /// method.
+        /// </remarks>
+        /// <param name="connectionString">The connection string.</param>
+        /// <returns>The transport connection.</returns>
+        Task<ITransportConnection> ConnectAsync(string connectionString);
+    }
+}

--- a/UaClient/ServiceModel/Ua/UaApplicationOptions.cs
+++ b/UaClient/ServiceModel/Ua/UaApplicationOptions.cs
@@ -68,4 +68,34 @@ namespace Workstation.ServiceModel.Ua
         /// </summary>
         public uint LocalMaxChunkCount { get; set; } = UaTcpTransportChannel.DefaultMaxChunkCount;
     }
+
+    /// <summary>
+    /// The transport connection options.
+    /// </summary>
+    public class TransportConnectionOptions
+    {
+        public const uint DefaultBufferSize = 64 * 1024;
+        public const uint DefaultMaxMessageSize = 16 * 1024 * 1024;
+        public const uint DefaultMaxChunkCount = 4 * 1024;
+
+        /// <summary>
+        /// Gets or sets the size of the receive buffer.
+        /// </summary>
+        public uint ReceiveBufferSize { get; set; } = DefaultBufferSize;
+
+        /// <summary>
+        /// Gets or sets the size of the send buffer.
+        /// </summary>
+        public uint SendBufferSize { get; set; } = DefaultBufferSize;
+
+        /// <summary>
+        /// Gets or sets the maximum total size of a message.
+        /// </summary>
+        public uint MaxMessageSize { get; set; } = DefaultMaxMessageSize;
+
+        /// <summary>
+        /// Gets or sets the maximum number of message chunks.
+        /// </summary>
+        public uint MaxChunkCount { get; set; } = DefaultMaxChunkCount;
+    }
 }


### PR DESCRIPTION
Here is the first step to the complete `StackProfile` implementation. In this PR I'm adding the interfaces for the connection part. I tried to introduce it in a very gentle way without breaking changes, yet. But there is one place where this didn't work out. Namely, the `UaTcpTransportChannel.Socket` will always return `null`.

There are some design consideration to be made:
 1. `ITransportConnection.SendAsync` takes `(byte[] buffer, int offset, int count, …)` as arguments. There are two possible alternatives: `ArraySegment<byte>` and `Memory<byte>`. I do like having a specialized type to represent the triple. We already use `ArraySegment` in some parts. The more modern choice would be `Memory<byte>`. While we could use the latter, as long as we support  netstandard 2.0, we cannot profit from the new API that was added to `Stream` in the latest .NET versions.  At the end all variants will work. 
 2. `ConnectAsync` takes the address as `string`, we could use `Uri` instead. Actually I first used `Uri` there. But when I played around with a `ServerListner`, it was more easier to use the `string` version, because you could use some shorter form like: `"127.0.0.1:4840"` instead of  `opc.tcp://127.0.0.1:4840`. Another argument was that I wanted to use the same type as `EndpointType.EndpointUrl`, that is `string`.
 3. All methods are `Task` based, we could use `ValueTask` instead.
 
 I do not have a strong opinion on all those topics, but I wanted to point out that there are some design decisions to be be made.
