### PR TITLE
StackProfile part 5: The great renaming

### DIFF
--- a/UaClient.UnitTests/IntegrationTests/IntegrationTests.cs
+++ b/UaClient.UnitTests/IntegrationTests/IntegrationTests.cs
@@ -111,7 +111,7 @@ namespace Workstation.UaClient.IntegrationTests
                 ProfileUris = new[] { TransportProfileUris.UaTcpTransport }
             };
             logger.LogInformation($"Discovering endpoints of '{getEndpointsRequest.EndpointUrl}'.");
-            var getEndpointsResponse = await UaTcpDiscoveryService.GetEndpointsAsync(getEndpointsRequest, loggerFactory);
+            var getEndpointsResponse = await DiscoveryService.GetEndpointsAsync(getEndpointsRequest, loggerFactory);
 
             // for each endpoint and user identity type, try creating a session and reading a few nodes.
             foreach (var selectedEndpoint in getEndpointsResponse.Endpoints.Where(e => e.SecurityPolicyUri == SecurityPolicyUris.None))
@@ -133,7 +133,7 @@ namespace Workstation.UaClient.IntegrationTests
                             continue;
                     }
 
-                    var channel = new UaTcpSessionChannel(
+                    var channel = new ClientSessionChannel(
                         localDescription,
                         null,
                         selectedUserIdentity,
@@ -167,7 +167,7 @@ namespace Workstation.UaClient.IntegrationTests
                 ProfileUris = new[] { TransportProfileUris.UaTcpTransport }
             };
             logger.LogInformation($"Discovering endpoints of '{getEndpointsRequest.EndpointUrl}'.");
-            var getEndpointsResponse = await UaTcpDiscoveryService.GetEndpointsAsync(getEndpointsRequest);
+            var getEndpointsResponse = await DiscoveryService.GetEndpointsAsync(getEndpointsRequest);
 
             // for each endpoint and user identity type, try creating a session and reading a few nodes.
             foreach (var selectedEndpoint in getEndpointsResponse.Endpoints
@@ -194,7 +194,7 @@ namespace Workstation.UaClient.IntegrationTests
                             continue;
                     }
 
-                    var channel = new UaTcpSessionChannel(
+                    var channel = new ClientSessionChannel(
                         localDescription,
                         certificateStore,
                         selectedUserIdentity,
@@ -221,7 +221,7 @@ namespace Workstation.UaClient.IntegrationTests
         [Fact]
         public async Task BrowseObjects()
         {
-            var channel = new UaTcpSessionChannel(
+            var channel = new ClientSessionChannel(
                 localDescription,
                 certificateStore,
                 new AnonymousIdentity(),
@@ -265,7 +265,7 @@ namespace Workstation.UaClient.IntegrationTests
         [Fact]
         public async Task Read()
         {
-            var channel = new UaTcpSessionChannel(
+            var channel = new ClientSessionChannel(
                 localDescription,
                 certificateStore,
                 new AnonymousIdentity(),
@@ -301,7 +301,7 @@ namespace Workstation.UaClient.IntegrationTests
         [Fact]
         public async Task Polling()
         {
-            var channel = new UaTcpSessionChannel(
+            var channel = new ClientSessionChannel(
                 localDescription,
                 certificateStore,
                 new AnonymousIdentity(),
@@ -334,7 +334,7 @@ namespace Workstation.UaClient.IntegrationTests
         [Fact]
         public async Task TestSubscription()
         {
-            var channel = new UaTcpSessionChannel(
+            var channel = new ClientSessionChannel(
                 localDescription,
                 certificateStore,
                 new AnonymousIdentity(),
@@ -418,7 +418,7 @@ namespace Workstation.UaClient.IntegrationTests
         [Fact]
         public async Task CustomVectorAdd()
         {
-            var channel = new UaTcpSessionChannel(
+            var channel = new ClientSessionChannel(
                 localDescription,
                 certificateStore,
                 new AnonymousIdentity(),
@@ -465,7 +465,7 @@ namespace Workstation.UaClient.IntegrationTests
         [Fact]
         public async Task ReadHistorical()
         {
-            var channel = new UaTcpSessionChannel(
+            var channel = new ClientSessionChannel(
                 localDescription,
                 certificateStore,
                 new AnonymousIdentity(),
@@ -652,7 +652,7 @@ namespace Workstation.UaClient.IntegrationTests
         [Fact]
         public async Task StackTest()
         {
-            var channel = new UaTcpSessionChannel(
+            var channel = new ClientSessionChannel(
                 localDescription,
                 certificateStore,
                 new AnonymousIdentity(),
@@ -735,7 +735,7 @@ namespace Workstation.UaClient.IntegrationTests
         [Fact]
         public async Task TransferSubscription()
         {
-            var channel1 = new UaTcpSessionChannel(
+            var channel1 = new ClientSessionChannel(
                 localDescription,
                 certificateStore,
                 new UserNameIdentity("root", "secret"),
@@ -793,7 +793,7 @@ namespace Workstation.UaClient.IntegrationTests
 
             await Task.Delay(3000);
 
-            var channel2 = new UaTcpSessionChannel(
+            var channel2 = new ClientSessionChannel(
                 localDescription,
                 certificateStore,
                 new UserNameIdentity("root", "secret"),
@@ -828,7 +828,7 @@ namespace Workstation.UaClient.IntegrationTests
         [Fact]
         public async Task StructureTest()
         {
-            var channel = new UaTcpSessionChannel(
+            var channel = new ClientSessionChannel(
                 localDescription,
                 certificateStore,
                 new AnonymousIdentity(),

--- a/UaClient.UnitTests/UnitTests/Channels/UaSecureConversationTests.cs
+++ b/UaClient.UnitTests/UnitTests/Channels/UaSecureConversationTests.cs
@@ -88,12 +88,12 @@ namespace Workstation.UaClient.UnitTests.Channels
             var client = await CreateClientConversationAsync(securityPolicyUri, mode);
             var server = CreateServerConversation(channelId, mode);
 
-            var result = await SendAndReceiveAsync(client, server, UaTcpMessageTypes.OPNF, handle, request);
+            var result = await SendAndReceiveAsync(client, server, MessageTypes.OPNF, handle, request);
 
             result.requestHandle
                 .Should().Be(handle);
             result.messageType
-                .Should().Be(UaTcpMessageTypes.OPNF);
+                .Should().Be(MessageTypes.OPNF);
             result.content
                 .Should().Equal(request);
         }
@@ -122,15 +122,15 @@ namespace Workstation.UaClient.UnitTests.Channels
             var client = await CreateClientConversationAsync(securityPolicyUri, mode);
             var server = CreateServerConversation(channelId, mode);
 
-            await SendAndReceiveAsync(client, server, UaTcpMessageTypes.OPNF, handle, request);
+            await SendAndReceiveAsync(client, server, MessageTypes.OPNF, handle, request);
             server.SecurityMode = mode;
-            var result = await SendAndReceiveAsync(server, client, UaTcpMessageTypes.OPNF, handle, response);
+            var result = await SendAndReceiveAsync(server, client, MessageTypes.OPNF, handle, response);
             client.TokenId = TokenId;
 
             result.requestHandle
                 .Should().Be(handle);
             result.messageType
-                .Should().Be(UaTcpMessageTypes.OPNF);
+                .Should().Be(MessageTypes.OPNF);
             result.content
                 .Should().Equal(response);
 
@@ -163,18 +163,18 @@ namespace Workstation.UaClient.UnitTests.Channels
             var client = await CreateClientConversationAsync(securityPolicyUri, mode);
             var server = CreateServerConversation(channelId, mode);
 
-            await SendAndReceiveAsync(client, server, UaTcpMessageTypes.OPNF, handle, openRequest);
+            await SendAndReceiveAsync(client, server, MessageTypes.OPNF, handle, openRequest);
             server.SecurityMode = mode;
-            await SendAndReceiveAsync(server, client, UaTcpMessageTypes.OPNF, handle, openResponse);
+            await SendAndReceiveAsync(server, client, MessageTypes.OPNF, handle, openResponse);
             client.TokenId = TokenId;
 
             handle++;
-            var result = await SendAndReceiveAsync(client, server, UaTcpMessageTypes.MSGA, handle, request);
+            var result = await SendAndReceiveAsync(client, server, MessageTypes.MSGA, handle, request);
 
             result.requestHandle
                 .Should().Be(handle);
             result.messageType
-                .Should().Be(UaTcpMessageTypes.MSGF);
+                .Should().Be(MessageTypes.MSGF);
             result.content
                 .Should().Equal(request);
 
@@ -208,19 +208,19 @@ namespace Workstation.UaClient.UnitTests.Channels
             var client = await CreateClientConversationAsync(securityPolicyUri, mode);
             var server = CreateServerConversation(channelId, mode);
 
-            await SendAndReceiveAsync(client, server, UaTcpMessageTypes.OPNF, handle, openRequest);
+            await SendAndReceiveAsync(client, server, MessageTypes.OPNF, handle, openRequest);
             server.SecurityMode = mode;
-            await SendAndReceiveAsync(server, client, UaTcpMessageTypes.OPNF, handle, openResponse);
+            await SendAndReceiveAsync(server, client, MessageTypes.OPNF, handle, openResponse);
             client.TokenId = TokenId;
 
             handle++;
-            await SendAndReceiveAsync(client, server, UaTcpMessageTypes.MSGA, handle, request);
-            var result = await SendAndReceiveAsync(server, client, UaTcpMessageTypes.MSGA, handle, response);
+            await SendAndReceiveAsync(client, server, MessageTypes.MSGA, handle, request);
+            var result = await SendAndReceiveAsync(server, client, MessageTypes.MSGA, handle, response);
 
             result.requestHandle
                 .Should().Be(handle);
             result.messageType
-                .Should().Be(UaTcpMessageTypes.MSGF);
+                .Should().Be(MessageTypes.MSGF);
             result.content
                 .Should().Equal(response);
 
@@ -255,22 +255,22 @@ namespace Workstation.UaClient.UnitTests.Channels
             var client = await CreateClientConversationAsync(securityPolicyUri, mode);
             var server = CreateServerConversation(channelId, mode);
 
-            await SendAndReceiveAsync(client, server, UaTcpMessageTypes.OPNF, handle, openRequest);
+            await SendAndReceiveAsync(client, server, MessageTypes.OPNF, handle, openRequest);
             server.SecurityMode = mode;
-            await SendAndReceiveAsync(server, client, UaTcpMessageTypes.OPNF, handle, openResponse);
+            await SendAndReceiveAsync(server, client, MessageTypes.OPNF, handle, openResponse);
             client.TokenId = TokenId;
 
             handle++;
-            await SendAndReceiveAsync(client, server, UaTcpMessageTypes.MSGA, handle, request);
-            await SendAndReceiveAsync(server, client, UaTcpMessageTypes.MSGA, handle, response);
+            await SendAndReceiveAsync(client, server, MessageTypes.MSGA, handle, request);
+            await SendAndReceiveAsync(server, client, MessageTypes.MSGA, handle, response);
 
             handle++;
-            var result = await SendAndReceiveAsync(client, server, UaTcpMessageTypes.CLOF, handle, closingRequest);
+            var result = await SendAndReceiveAsync(client, server, MessageTypes.CLOF, handle, closingRequest);
 
             result.requestHandle
                 .Should().Be(handle);
             result.messageType
-                .Should().Be(UaTcpMessageTypes.CLOF);
+                .Should().Be(MessageTypes.CLOF);
             result.content
                 .Should().Equal(closingRequest);
 
@@ -306,23 +306,23 @@ namespace Workstation.UaClient.UnitTests.Channels
             var client = await CreateClientConversationAsync(securityPolicyUri, mode);
             var server = CreateServerConversation(channelId, mode);
 
-            await SendAndReceiveAsync(client, server, UaTcpMessageTypes.OPNF, handle, openRequest);
+            await SendAndReceiveAsync(client, server, MessageTypes.OPNF, handle, openRequest);
             server.SecurityMode = mode;
-            await SendAndReceiveAsync(server, client, UaTcpMessageTypes.OPNF, handle, openResponse);
+            await SendAndReceiveAsync(server, client, MessageTypes.OPNF, handle, openResponse);
             client.TokenId = TokenId;
 
             handle++;
-            await SendAndReceiveAsync(client, server, UaTcpMessageTypes.MSGA, handle, request);
-            await SendAndReceiveAsync(server, client, UaTcpMessageTypes.MSGA, handle, response);
+            await SendAndReceiveAsync(client, server, MessageTypes.MSGA, handle, request);
+            await SendAndReceiveAsync(server, client, MessageTypes.MSGA, handle, response);
 
             handle++;
-            await SendAndReceiveAsync(client, server, UaTcpMessageTypes.CLOF, handle, closingRequest);
-            var result = await SendAndReceiveAsync(server, client, UaTcpMessageTypes.CLOF, handle, closingResponse);
+            await SendAndReceiveAsync(client, server, MessageTypes.CLOF, handle, closingRequest);
+            var result = await SendAndReceiveAsync(server, client, MessageTypes.CLOF, handle, closingResponse);
 
             result.requestHandle
                 .Should().Be(handle);
             result.messageType
-                .Should().Be(UaTcpMessageTypes.CLOF);
+                .Should().Be(MessageTypes.CLOF);
             result.content
                 .Should().Equal(closingResponse);
 

--- a/UaClient.UnitTests/UnitTests/UaApplicationOptionsTests.cs
+++ b/UaClient.UnitTests/UnitTests/UaApplicationOptionsTests.cs
@@ -10,11 +10,11 @@ namespace Workstation.UaClient.UnitTests
     public class UaApplicationOptionsTests
     {
         [Fact]
-        public void UaTcpTransportChannelOptionsDefaults()
+        public void ClientTransportChannelOptionsDefaults()
         {
             var lowestBufferSize = 8192u;
 
-            var options = new UaTcpTransportChannelOptions();
+            var options = new ClientTransportChannelOptions();
 
             options.LocalReceiveBufferSize
                 .Should().BeGreaterOrEqualTo(lowestBufferSize);
@@ -23,11 +23,11 @@ namespace Workstation.UaClient.UnitTests
         }
 
         [Fact]
-        public void UaTcpSecureChannelOptionsDefaults()
+        public void ClientSecureChannelOptionsDefaults()
         {
             var shortestTimespan = TimeSpan.FromMilliseconds(100);
 
-            var options = new UaTcpSecureChannelOptions();
+            var options = new ClientSecureChannelOptions();
 
             TimeSpan.FromMilliseconds(options.TimeoutHint)
                 .Should().BeGreaterOrEqualTo(shortestTimespan);
@@ -37,11 +37,11 @@ namespace Workstation.UaClient.UnitTests
         }
 
         [Fact]
-        public void UaTcpSessionChannelOptionsDefaults()
+        public void ClientSessionChannelOptionsDefaults()
         {
             var shortestTimespan = TimeSpan.FromMilliseconds(100);
 
-            var options = new UaTcpSessionChannelOptions();
+            var options = new ClientSessionChannelOptions();
 
             TimeSpan.FromMilliseconds(options.SessionTimeout)
                 .Should().BeGreaterOrEqualTo(shortestTimespan);

--- a/UaClient/ServiceModel/Ua/Channels/ClientSecureChannel.cs
+++ b/UaClient/ServiceModel/Ua/Channels/ClientSecureChannel.cs
@@ -19,7 +19,7 @@ namespace Workstation.ServiceModel.Ua.Channels
     /// <summary>
     /// A secure channel for communicating with OPC UA servers using the UA TCP transport profile.
     /// </summary>
-    public class UaTcpSecureChannel : UaTcpTransportChannel, IRequestChannel, IEncodingContext
+    public class ClientSecureChannel : ClientTransportChannel, IRequestChannel, IEncodingContext
     {
         /// <summary>
         /// The default timeout for requests.
@@ -48,27 +48,28 @@ namespace Workstation.ServiceModel.Ua.Channels
         private IConversation? _conversation;
 
         /// <summary>
-        /// Initializes a new instance of the <see cref="UaTcpSecureChannel"/> class.
+        /// Initializes a new instance of the <see cref="ClientSecureChannel"/> class.
         /// </summary>
         /// <param name="localDescription">The local description.</param>
         /// <param name="certificateStore">The local certificate store.</param>
         /// <param name="remoteEndpoint">The remote endpoint</param>
         /// <param name="loggerFactory">The logger factory.</param>
         /// <param name="options">The secure channel options.</param>
-        public UaTcpSecureChannel(
+        public ClientSecureChannel(
             ApplicationDescription localDescription,
             ICertificateStore? certificateStore,
             EndpointDescription remoteEndpoint,
             ILoggerFactory? loggerFactory = null,
-            UaTcpSecureChannelOptions? options = null)
-            : base(remoteEndpoint, loggerFactory, options)
+            ClientSecureChannelOptions? options = null,
+            StackProfile? stackProfile = null)
+            : base(remoteEndpoint, loggerFactory, options, stackProfile)
         {
             LocalDescription = localDescription ?? throw new ArgumentNullException(nameof(localDescription));
             CertificateStore = certificateStore;
             TimeoutHint = options?.TimeoutHint ?? DefaultTimeoutHint;
             DiagnosticsHint = options?.DiagnosticsHint ?? DefaultDiagnosticsHint;
 
-            _logger = loggerFactory?.CreateLogger<UaTcpSecureChannel>();
+            _logger = loggerFactory?.CreateLogger<ClientSecureChannel>();
 
             AuthenticationToken = null;
             NamespaceUris = new List<string> { "http://opcfoundation.org/UA/" };
@@ -337,7 +338,7 @@ namespace Workstation.ServiceModel.Ua.Channels
                 bodyStream.Position = 0;
 
                 var handle = request.RequestHeader!.RequestHandle;
-                await _conversation!.EncryptMessageAsync(bodyStream, UaTcpMessageTypes.OPNF, handle, SendAsync, token);
+                await _conversation!.EncryptMessageAsync(bodyStream, MessageTypes.OPNF, handle, SendAsync, token);
             }
         }
 
@@ -356,7 +357,7 @@ namespace Workstation.ServiceModel.Ua.Channels
                 bodyStream.Position = 0;
 
                 var handle = request.RequestHeader!.RequestHandle;
-                await _conversation!.EncryptMessageAsync(bodyStream, UaTcpMessageTypes.CLOF, handle, SendAsync, token);
+                await _conversation!.EncryptMessageAsync(bodyStream, MessageTypes.CLOF, handle, SendAsync, token);
             }
         }
 
@@ -375,7 +376,7 @@ namespace Workstation.ServiceModel.Ua.Channels
                 bodyStream.Position = 0;
 
                 var handle = request.RequestHeader!.RequestHandle;
-                await _conversation!.EncryptMessageAsync(bodyStream, UaTcpMessageTypes.MSGF, handle, SendAsync, token);
+                await _conversation!.EncryptMessageAsync(bodyStream, MessageTypes.MSGF, handle, SendAsync, token);
             }
         }
 

--- a/UaClient/ServiceModel/Ua/Channels/ClientSecureChannel.cs
+++ b/UaClient/ServiceModel/Ua/Channels/ClientSecureChannel.cs
@@ -17,7 +17,7 @@ using Org.BouncyCastle.Crypto.Parameters;
 namespace Workstation.ServiceModel.Ua.Channels
 {
     /// <summary>
-    /// A secure channel for communicating with OPC UA servers using the UA TCP transport profile.
+    /// A secure channel for communicating with OPC UA servers.
     /// </summary>
     public class ClientSecureChannel : ClientTransportChannel, IRequestChannel, IEncodingContext
     {

--- a/UaClient/ServiceModel/Ua/Channels/ClientSecureChannel.cs
+++ b/UaClient/ServiceModel/Ua/Channels/ClientSecureChannel.cs
@@ -105,12 +105,6 @@ namespace Workstation.ServiceModel.Ua.Channels
         protected byte[]? RemoteCertificate => RemoteEndpoint?.ServerCertificate;
 
         /// <summary>
-        /// Gets the local nonce.
-        /// </summary>
-        [Obsolete]
-        protected byte[]? LocalNonce => null;
-
-        /// <summary>
         /// Gets or sets the channel id.
         /// </summary>
         public uint ChannelId => _conversation?.ChannelId ?? 0;

--- a/UaClient/ServiceModel/Ua/Channels/ClientSessionChannel.cs
+++ b/UaClient/ServiceModel/Ua/Channels/ClientSessionChannel.cs
@@ -19,7 +19,7 @@ namespace Workstation.ServiceModel.Ua.Channels
     /// <summary>
     /// A session-full, secure channel for communicating with OPC UA servers using the UA TCP transport profile.
     /// </summary>
-    public class UaTcpSessionChannel : UaTcpSecureChannel, ISourceBlock<PublishResponse>, IObservable<PublishResponse>
+    public class ClientSessionChannel : ClientSecureChannel, ISourceBlock<PublishResponse>, IObservable<PublishResponse>
     {
         /// <summary>
         /// The default session timeout.
@@ -57,39 +57,40 @@ namespace Workstation.ServiceModel.Ua.Channels
         private readonly ILogger? _logger;
         private readonly BroadcastBlock<PublishResponse> _publishResponses;
         private readonly ActionBlock<PublishResponse> _actionBlock;
-        private readonly UaTcpSessionChannelOptions _options;
+        private readonly ClientSessionChannelOptions _options;
         private readonly CancellationTokenSource _stateMachineCts;
         private Task? _stateMachineTask;
 
         /// <summary>
-        /// Initializes a new instance of the <see cref="UaTcpSessionChannel"/> class.
+        /// Initializes a new instance of the <see cref="ClientSessionChannel"/> class.
         /// </summary>
         /// <param name="localDescription">The <see cref="ApplicationDescription"/> of the local application.</param>
         /// <param name="certificateStore">The local certificate store.</param>
         /// <param name="userIdentity">The user identity. Provide an <see cref="AnonymousIdentity"/>, <see cref="UserNameIdentity"/>, <see cref="IssuedIdentity"/> or <see cref="X509Identity"/>.</param>
-        /// <param name="remoteEndpoint">The <see cref="EndpointDescription"/> of the remote application. Obtained from a prior call to UaTcpDiscoveryClient.GetEndpoints.</param>
+        /// <param name="remoteEndpoint">The <see cref="EndpointDescription"/> of the remote application. Obtained from a prior call to <see cref="DiscoveryService.GetEndpointsAsync(GetEndpointsRequest, ILoggerFactory?, UaApplicationOptions?, StackProfile?)"/>.</param>
         /// <param name="loggerFactory">The logger factory.</param>
         /// <param name="options">The session channel options.</param>
-        public UaTcpSessionChannel(
+        public ClientSessionChannel(
             ApplicationDescription localDescription,
             ICertificateStore? certificateStore,
             IUserIdentity userIdentity,
             EndpointDescription remoteEndpoint,
             ILoggerFactory? loggerFactory = null,
-            UaTcpSessionChannelOptions? options = null)
-            : base(localDescription, certificateStore, remoteEndpoint, loggerFactory, options)
+            ClientSessionChannelOptions? options = null,
+            StackProfile? stackProfile = null)
+            : base(localDescription, certificateStore, remoteEndpoint, loggerFactory, options, stackProfile)
         {
             UserIdentity = userIdentity;
-            _options = options ?? new UaTcpSessionChannelOptions();
+            _options = options ?? new ClientSessionChannelOptions();
             _loggerFactory = loggerFactory;
-            _logger = loggerFactory?.CreateLogger<UaTcpSessionChannel>();
+            _logger = loggerFactory?.CreateLogger<ClientSessionChannel>();
             _actionBlock = new ActionBlock<PublishResponse>(pr => OnPublishResponse(pr));
             _stateMachineCts = new CancellationTokenSource();
             _publishResponses = new BroadcastBlock<PublishResponse>(null, new DataflowBlockOptions { CancellationToken = _stateMachineCts.Token });
         }
 
         /// <summary>
-        /// Initializes a new instance of the <see cref="UaTcpSessionChannel"/> class.
+        /// Initializes a new instance of the <see cref="ClientSessionChannel"/> class.
         /// </summary>
         /// <param name="localDescription">The <see cref="ApplicationDescription"/> of the local application.</param>
         /// <param name="certificateStore">The local certificate store.</param>
@@ -98,27 +99,28 @@ namespace Workstation.ServiceModel.Ua.Channels
         /// <param name="securityPolicyUri">Optionally, filter by SecurityPolicyUri.</param>
         /// <param name="loggerFactory">The logger factory.</param>
         /// <param name="options">The session channel options.</param>
-        public UaTcpSessionChannel(
+        public ClientSessionChannel(
             ApplicationDescription localDescription,
             ICertificateStore? certificateStore,
             IUserIdentity? userIdentity,
             string endpointUrl,
             string? securityPolicyUri = null,
             ILoggerFactory? loggerFactory = null,
-            UaTcpSessionChannelOptions? options = null)
-            : base(localDescription, certificateStore, new EndpointDescription { EndpointUrl = endpointUrl, SecurityPolicyUri = securityPolicyUri }, loggerFactory, options)
+            ClientSessionChannelOptions? options = null,
+            StackProfile? stackProfile = null)
+            : base(localDescription, certificateStore, new EndpointDescription { EndpointUrl = endpointUrl, SecurityPolicyUri = securityPolicyUri }, loggerFactory, options, stackProfile)
         {
             UserIdentity = userIdentity;
-            _options = options ?? new UaTcpSessionChannelOptions();
+            _options = options ?? new ClientSessionChannelOptions();
             _loggerFactory = loggerFactory;
-            _logger = loggerFactory?.CreateLogger<UaTcpSessionChannel>();
+            _logger = loggerFactory?.CreateLogger<ClientSessionChannel>();
             _actionBlock = new ActionBlock<PublishResponse>(pr => OnPublishResponse(pr));
             _stateMachineCts = new CancellationTokenSource();
             _publishResponses = new BroadcastBlock<PublishResponse>(null, new DataflowBlockOptions { CancellationToken = _stateMachineCts.Token });
         }
 
         /// <summary>
-        /// Initializes a new instance of the <see cref="UaTcpSessionChannel"/> class.
+        /// Initializes a new instance of the <see cref="ClientSessionChannel"/> class.
         /// </summary>
         /// <param name="localDescription">The <see cref="ApplicationDescription"/> of the local application.</param>
         /// <param name="certificateStore">The local certificate store.</param>
@@ -126,26 +128,27 @@ namespace Workstation.ServiceModel.Ua.Channels
         /// <param name="remoteEndpoint">The <see cref="EndpointDescription"/> of the remote application. Obtained from a prior call to UaTcpDiscoveryClient.GetEndpoints.</param>
         /// <param name="loggerFactory">The logger factory.</param>
         /// <param name="options">The session channel options.</param>
-        public UaTcpSessionChannel(
+        public ClientSessionChannel(
             ApplicationDescription localDescription,
             ICertificateStore? certificateStore,
             Func<EndpointDescription, Task<IUserIdentity>>? userIdentityProvider,
             EndpointDescription remoteEndpoint,
             ILoggerFactory? loggerFactory = null,
-            UaTcpSessionChannelOptions? options = null)
-            : base(localDescription, certificateStore, remoteEndpoint, loggerFactory, options)
+            ClientSessionChannelOptions? options = null,
+            StackProfile? stackProfile = null)
+            : base(localDescription, certificateStore, remoteEndpoint, loggerFactory, options, stackProfile)
         {
             UserIdentityProvider = userIdentityProvider;
-            _options = options ?? new UaTcpSessionChannelOptions();
+            _options = options ?? new ClientSessionChannelOptions();
             _loggerFactory = loggerFactory;
-            _logger = loggerFactory?.CreateLogger<UaTcpSessionChannel>();
+            _logger = loggerFactory?.CreateLogger<ClientSessionChannel>();
             _actionBlock = new ActionBlock<PublishResponse>(pr => OnPublishResponse(pr));
             _stateMachineCts = new CancellationTokenSource();
             _publishResponses = new BroadcastBlock<PublishResponse>(null, new DataflowBlockOptions { CancellationToken = _stateMachineCts.Token });
         }
 
         /// <summary>
-        /// Initializes a new instance of the <see cref="UaTcpSessionChannel"/> class.
+        /// Initializes a new instance of the <see cref="ClientSessionChannel"/> class.
         /// </summary>
         /// <param name="localDescription">The <see cref="ApplicationDescription"/> of the local application.</param>
         /// <param name="certificateStore">The local certificate store.</param>
@@ -154,20 +157,21 @@ namespace Workstation.ServiceModel.Ua.Channels
         /// <param name="securityPolicyUri">Optionally, filter by SecurityPolicyUri.</param>
         /// <param name="loggerFactory">The logger factory.</param>
         /// <param name="options">The session channel options.</param>
-        public UaTcpSessionChannel(
+        public ClientSessionChannel(
             ApplicationDescription localDescription,
             ICertificateStore certificateStore,
             Func<EndpointDescription, Task<IUserIdentity>> userIdentityProvider,
             string endpointUrl,
             string? securityPolicyUri = null,
             ILoggerFactory? loggerFactory = null,
-            UaTcpSessionChannelOptions? options = null)
-            : base(localDescription, certificateStore, new EndpointDescription { EndpointUrl = endpointUrl, SecurityPolicyUri = securityPolicyUri }, loggerFactory, options)
+            ClientSessionChannelOptions? options = null,
+            StackProfile? stackProfile = null)
+            : base(localDescription, certificateStore, new EndpointDescription { EndpointUrl = endpointUrl, SecurityPolicyUri = securityPolicyUri }, loggerFactory, options, stackProfile)
         {
             UserIdentityProvider = userIdentityProvider;
-            _options = options ?? new UaTcpSessionChannelOptions();
+            _options = options ?? new ClientSessionChannelOptions();
             _loggerFactory = loggerFactory;
-            _logger = loggerFactory?.CreateLogger<UaTcpSessionChannel>();
+            _logger = loggerFactory?.CreateLogger<ClientSessionChannel>();
             _actionBlock = new ActionBlock<PublishResponse>(pr => OnPublishResponse(pr));
             _stateMachineCts = new CancellationTokenSource();
             _publishResponses = new BroadcastBlock<PublishResponse>(null, new DataflowBlockOptions { CancellationToken = _stateMachineCts.Token });
@@ -272,7 +276,7 @@ namespace Workstation.ServiceModel.Ua.Channels
                         EndpointUrl = endpointUrl,
                         ProfileUris = new[] { TransportProfileUris.UaTcpTransport }
                     };
-                    var getEndpointsResponse = await UaTcpDiscoveryService.GetEndpointsAsync(getEndpointsRequest, _loggerFactory).ConfigureAwait(false);
+                    var getEndpointsResponse = await DiscoveryService.GetEndpointsAsync(getEndpointsRequest, _loggerFactory, stackProfile: StackProfile).ConfigureAwait(false);
                     if (getEndpointsResponse.Endpoints == null || getEndpointsResponse.Endpoints.Length == 0)
                     {
                         throw new InvalidOperationException($"'{endpointUrl}' returned no endpoints.");

--- a/UaClient/ServiceModel/Ua/Channels/ClientSessionChannel.cs
+++ b/UaClient/ServiceModel/Ua/Channels/ClientSessionChannel.cs
@@ -17,7 +17,7 @@ using Org.BouncyCastle.X509;
 namespace Workstation.ServiceModel.Ua.Channels
 {
     /// <summary>
-    /// A session-full, secure channel for communicating with OPC UA servers using the UA TCP transport profile.
+    /// A session-full, secure channel for communicating with OPC UA servers.
     /// </summary>
     public class ClientSessionChannel : ClientSecureChannel, ISourceBlock<PublishResponse>, IObservable<PublishResponse>
     {
@@ -125,7 +125,7 @@ namespace Workstation.ServiceModel.Ua.Channels
         /// <param name="localDescription">The <see cref="ApplicationDescription"/> of the local application.</param>
         /// <param name="certificateStore">The local certificate store.</param>
         /// <param name="userIdentityProvider">An asynchronous function that provides the user identity. Provide an <see cref="AnonymousIdentity"/>, <see cref="UserNameIdentity"/>, <see cref="IssuedIdentity"/> or <see cref="X509Identity"/>.</param>
-        /// <param name="remoteEndpoint">The <see cref="EndpointDescription"/> of the remote application. Obtained from a prior call to UaTcpDiscoveryClient.GetEndpoints.</param>
+        /// <param name="remoteEndpoint">The <see cref="EndpointDescription"/> of the remote application. Obtained from a prior call to <see cref="DiscoveryService.GetEndpointsAsync(GetEndpointsRequest, ILoggerFactory?, UaApplicationOptions?, StackProfile?)" /> .</param>
         /// <param name="loggerFactory">The logger factory.</param>
         /// <param name="options">The session channel options.</param>
         public ClientSessionChannel(
@@ -274,7 +274,7 @@ namespace Workstation.ServiceModel.Ua.Channels
                     var getEndpointsRequest = new GetEndpointsRequest
                     {
                         EndpointUrl = endpointUrl,
-                        ProfileUris = new[] { TransportProfileUris.UaTcpTransport }
+                        ProfileUris = new[] { TransportProfileUris.UaTcpTransport } // We should rethink this line, once we support transport profiles.
                     };
                     var getEndpointsResponse = await DiscoveryService.GetEndpointsAsync(getEndpointsRequest, _loggerFactory, stackProfile: StackProfile).ConfigureAwait(false);
                     if (getEndpointsResponse.Endpoints == null || getEndpointsResponse.Endpoints.Length == 0)

--- a/UaClient/ServiceModel/Ua/Channels/ClientTransportChannel.cs
+++ b/UaClient/ServiceModel/Ua/Channels/ClientTransportChannel.cs
@@ -96,12 +96,6 @@ namespace Workstation.ServiceModel.Ua.Channels
         public uint RemoteMaxChunkCount { get; private set; }
 
         /// <summary>
-        /// Gets the inner TCP socket.
-        /// </summary>
-        [Obsolete]
-        protected virtual Socket? Socket => null;
-
-        /// <summary>
         /// Asynchronously sends a sequence of bytes to the remote endpoint.
         /// </summary>
         /// <param name="buffer">The buffer.</param>

--- a/UaClient/ServiceModel/Ua/Channels/ClientTransportChannel.cs
+++ b/UaClient/ServiceModel/Ua/Channels/ClientTransportChannel.cs
@@ -12,7 +12,7 @@ namespace Workstation.ServiceModel.Ua.Channels
     /// <summary>
     /// A channel for communicating with OPC UA servers using the UA TCP transport profile.
     /// </summary>
-    public class UaTcpTransportChannel : CommunicationObject
+    public class ClientTransportChannel : CommunicationObject
     {
         public const uint ProtocolVersion = 0u;
         public const uint DefaultBufferSize = 64 * 1024;
@@ -23,19 +23,22 @@ namespace Workstation.ServiceModel.Ua.Channels
         private ITransportConnection? _connection;
 
         /// <summary>
-        /// Initializes a new instance of the <see cref="UaTcpTransportChannel"/> class.
+        /// Initializes a new instance of the <see cref="ClientTransportChannel"/> class.
         /// </summary>
         /// <param name="remoteEndpoint">The remote endpoint.</param>
         /// <param name="loggerFactory">The logger factory.</param>
         /// <param name="options">The transport channel options.</param>
-        public UaTcpTransportChannel(
+        public ClientTransportChannel(
             EndpointDescription remoteEndpoint,
             ILoggerFactory? loggerFactory = null,
-            UaTcpTransportChannelOptions? options = null)
+            ClientTransportChannelOptions? options = null,
+            StackProfile? stackProfile = null)
             : base(loggerFactory)
         {
             RemoteEndpoint = remoteEndpoint ?? throw new ArgumentNullException(nameof(remoteEndpoint));
-            _logger = loggerFactory?.CreateLogger<UaTcpTransportChannel>();
+            StackProfile = stackProfile ?? StackProfiles.GetStackProfile(remoteEndpoint);
+            _logger = loggerFactory?.CreateLogger<ClientTransportChannel>();
+
             LocalReceiveBufferSize = options?.LocalReceiveBufferSize ?? DefaultBufferSize;
             LocalSendBufferSize = options?.LocalSendBufferSize ?? DefaultBufferSize;
             LocalMaxMessageSize = options?.LocalMaxMessageSize ?? DefaultMaxMessageSize;

--- a/UaClient/ServiceModel/Ua/Channels/ClientTransportChannel.cs
+++ b/UaClient/ServiceModel/Ua/Channels/ClientTransportChannel.cs
@@ -10,7 +10,7 @@ using Microsoft.Extensions.Logging;
 namespace Workstation.ServiceModel.Ua.Channels
 {
     /// <summary>
-    /// A channel for communicating with OPC UA servers using the UA TCP transport profile.
+    /// A channel for communicating with OPC UA servers.
     /// </summary>
     public class ClientTransportChannel : CommunicationObject
     {

--- a/UaClient/ServiceModel/Ua/Channels/MessageTypes.cs
+++ b/UaClient/ServiceModel/Ua/Channels/MessageTypes.cs
@@ -3,7 +3,7 @@
 
 namespace Workstation.ServiceModel.Ua
 {
-    public static class UaTcpMessageTypes
+    public static class MessageTypes
     {
         public const uint HELF = 'H' | 'E' << 8 | 'L' << 16 | 'F' << 24;
         public const uint ACKF = 'A' | 'C' << 8 | 'K' << 16 | 'F' << 24;

--- a/UaClient/ServiceModel/Ua/Channels/StackProfiles.cs
+++ b/UaClient/ServiceModel/Ua/Channels/StackProfiles.cs
@@ -1,6 +1,8 @@
 ﻿// Copyright (c) Converter Systems LLC. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using System;
+
 namespace Workstation.ServiceModel.Ua.Channels
 {
     public static class StackProfiles
@@ -15,5 +17,26 @@ namespace Workstation.ServiceModel.Ua.Channels
                     new UaSecureConversationProvider(),
                     new BinaryEncodingProvider()
                 );
+
+        /// <summary>
+        /// Get the <see cref="StackProfile"/> for the given endpoint.
+        /// </summary>
+        /// <remarks>
+        /// If no ´matching stack is found, <see cref="TcpUascBinary"/> will
+        /// be returned.
+        /// </remarks>
+        /// <param name="remoteEndpoint">The endpoint.</param>
+        /// <returns>A matching stack.</returns>
+        public static StackProfile GetStackProfile(EndpointDescription remoteEndpoint)
+        {
+            switch (remoteEndpoint.TransportProfileUri)
+            {
+                case TransportProfileUris.UaTcpTransport:
+                    return TcpUascBinary;
+                 // Use TcpUascBinary as fallback, or should we throw here?
+                default:
+                    return TcpUascBinary;
+            }
+        }
     }
 }

--- a/UaClient/ServiceModel/Ua/Channels/UaClientConnection.cs
+++ b/UaClient/ServiceModel/Ua/Channels/UaClientConnection.cs
@@ -74,7 +74,7 @@ namespace Workstation.ServiceModel.Ua.Channels
             var encoder = new BinaryEncoder(new MemoryStream(sendBuffer, 0, MinBufferSize, true, false));
             try
             {
-                encoder.WriteUInt32(null, UaTcpMessageTypes.HELF);
+                encoder.WriteUInt32(null, MessageTypes.HELF);
                 encoder.WriteUInt32(null, 0u);
                 encoder.WriteUInt32(null, protocolVersion);
                 encoder.WriteUInt32(null, localOptions.ReceiveBufferSize);
@@ -107,7 +107,7 @@ namespace Workstation.ServiceModel.Ua.Channels
             {
                 var type = decoder.ReadUInt32(null);
                 var len = decoder.ReadUInt32(null);
-                if (type == UaTcpMessageTypes.ACKF)
+                if (type == MessageTypes.ACKF)
                 {
                     var remoteProtocolVersion = decoder.ReadUInt32(null);
                     if (remoteProtocolVersion < protocolVersion)
@@ -125,7 +125,7 @@ namespace Workstation.ServiceModel.Ua.Channels
 
                     return remoteOptions;
                 }
-                else if (type == UaTcpMessageTypes.ERRF)
+                else if (type == MessageTypes.ERRF)
                 {
                     var statusCode = decoder.ReadUInt32(null);
                     var message = decoder.ReadString(null);

--- a/UaClient/ServiceModel/Ua/Channels/UaSecureConversation.cs
+++ b/UaClient/ServiceModel/Ua/Channels/UaSecureConversation.cs
@@ -380,7 +380,7 @@ namespace Workstation.ServiceModel.Ua.Channels
         /// <inheritdoc />
         public Task EncryptMessageAsync(Stream bodyStream, uint messageType, uint requestHandle, Func<byte[], int, int, CancellationToken, Task> consume, CancellationToken token)
         {
-            if (messageType == UaTcpMessageTypes.OPNF)
+            if (messageType == MessageTypes.OPNF)
             {
                 return EncryptOpenMessage(bodyStream, messageType, requestHandle, consume, token);
             }
@@ -725,9 +725,9 @@ namespace Workstation.ServiceModel.Ua.Channels
                     Debug.Assert(count == messageLength, "Bytes received not equal to encoded Message length");
                     switch (messageType)
                     {
-                        case UaTcpMessageTypes.MSGF:
-                        case UaTcpMessageTypes.MSGC:
-                        case UaTcpMessageTypes.CLOF:
+                        case MessageTypes.MSGF:
+                        case MessageTypes.MSGC:
+                        case MessageTypes.CLOF:
                             // header
                             channelId = decoder.ReadUInt32(null);
                             if (channelId != ChannelId)
@@ -809,10 +809,10 @@ namespace Workstation.ServiceModel.Ua.Channels
                             }
 
                             bodyStream.Write(_receiveBuffer!, plainHeaderSize + _sequenceHeaderSize, bodySize);
-                            isFinal = messageType == UaTcpMessageTypes.MSGF || messageType == UaTcpMessageTypes.CLOF;
+                            isFinal = messageType == MessageTypes.MSGF || messageType == MessageTypes.CLOF;
                             break;
 
-                        case UaTcpMessageTypes.OPNF:
+                        case MessageTypes.OPNF:
                             // header
                             channelId = decoder.ReadUInt32(null);
                             if (!IsServer)
@@ -890,11 +890,11 @@ namespace Workstation.ServiceModel.Ua.Channels
                             }
 
                             bodyStream.Write(_receiveBuffer!, plainHeaderSize + _sequenceHeaderSize, bodySize);
-                            isFinal = messageType == UaTcpMessageTypes.OPNF;
+                            isFinal = messageType == MessageTypes.OPNF;
                             break;
 
-                        case UaTcpMessageTypes.ERRF:
-                        case UaTcpMessageTypes.MSGA:
+                        case MessageTypes.ERRF:
+                        case MessageTypes.MSGA:
                             var statusCode = (StatusCode)decoder.ReadUInt32(null);
                             var message = decoder.ReadString(null);
                             if (message != null)

--- a/UaClient/ServiceModel/Ua/DiscoveryService.cs
+++ b/UaClient/ServiceModel/Ua/DiscoveryService.cs
@@ -12,17 +12,17 @@ namespace Workstation.ServiceModel.Ua
     /// <summary>
     /// A service for discovery of remote OPC UA servers and their endpoints.
     /// </summary>
-    public class UaTcpDiscoveryService : ICommunicationObject
+    public class DiscoveryService : ICommunicationObject
     {
-        private readonly UaTcpSecureChannel innerChannel;
+        private readonly ClientSecureChannel innerChannel;
         private readonly SemaphoreSlim semaphore;
         private readonly ILogger? logger;
 
-        private UaTcpDiscoveryService(EndpointDescription remoteEndpoint, ILoggerFactory? loggerFactory = null, UaTcpSecureChannelOptions? options = null)
+        private DiscoveryService(EndpointDescription remoteEndpoint, ILoggerFactory? loggerFactory = null, ClientSecureChannelOptions? options = null, StackProfile? stackProfile = null)
         {
-            this.innerChannel = new UaTcpSecureChannel(new ApplicationDescription { ApplicationName = nameof(UaTcpDiscoveryService) }, null, remoteEndpoint, loggerFactory, options);
+            this.innerChannel = new ClientSecureChannel(new ApplicationDescription { ApplicationName = nameof(DiscoveryService) }, null, remoteEndpoint, loggerFactory, options, stackProfile);
             this.semaphore = new SemaphoreSlim(1);
-            this.logger = loggerFactory?.CreateLogger<UaTcpDiscoveryService>();
+            this.logger = loggerFactory?.CreateLogger<DiscoveryService>();
         }
 
         /// <summary>
@@ -41,14 +41,14 @@ namespace Workstation.ServiceModel.Ua
         /// <param name="request">a request.</param>
         /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
         /// <seealso href="https://reference.opcfoundation.org/v104/Core/docs/Part4/5.4.2/">OPC UA specification Part 4: Services, 5.4.2</seealso>
-        public static async Task<FindServersResponse> FindServersAsync(FindServersRequest request, ILoggerFactory? loggerFactory = null, UaApplicationOptions? options = null)
+        public static async Task<FindServersResponse> FindServersAsync(FindServersRequest request, ILoggerFactory? loggerFactory = null, UaApplicationOptions? options = null, StackProfile? stackProfile = null)
         {
             if (request == null)
             {
                 throw new ArgumentNullException(nameof(request));
             }
 
-            var client = new UaTcpDiscoveryService(
+            var client = new DiscoveryService(
                 new EndpointDescription
                 {
                     EndpointUrl = request.EndpointUrl,
@@ -56,7 +56,8 @@ namespace Workstation.ServiceModel.Ua
                     SecurityPolicyUri = SecurityPolicyUris.None
                 },
                 loggerFactory,
-                options);
+                options,
+                stackProfile);
             try
             {
                 await client.OpenAsync().ConfigureAwait(false);
@@ -79,14 +80,14 @@ namespace Workstation.ServiceModel.Ua
         /// <param name="options">The secure channel options.</param>
         /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
         /// <seealso href="https://reference.opcfoundation.org/v104/Core/docs/Part4/5.4.4/">OPC UA specification Part 4: Services, 5.4.4</seealso>
-        public static async Task<GetEndpointsResponse> GetEndpointsAsync(GetEndpointsRequest request, ILoggerFactory? loggerFactory = null, UaApplicationOptions? options = null)
+        public static async Task<GetEndpointsResponse> GetEndpointsAsync(GetEndpointsRequest request, ILoggerFactory? loggerFactory = null, UaApplicationOptions? options = null, StackProfile? stackProfile = null)
         {
             if (request == null)
             {
                 throw new ArgumentNullException(nameof(request));
             }
 
-            var client = new UaTcpDiscoveryService(
+            var client = new DiscoveryService(
                 new EndpointDescription
                 {
                     EndpointUrl = request.EndpointUrl,
@@ -94,7 +95,8 @@ namespace Workstation.ServiceModel.Ua
                     SecurityPolicyUri = SecurityPolicyUris.None
                 },
                 loggerFactory,
-                options);
+                options,
+                stackProfile);
             try
             {
                 await client.OpenAsync().ConfigureAwait(false);

--- a/UaClient/ServiceModel/Ua/IConversation.cs
+++ b/UaClient/ServiceModel/Ua/IConversation.cs
@@ -43,7 +43,7 @@ namespace Workstation.ServiceModel.Ua
         /// <paramref name="consume"/> delegate.
         /// </summary>
         /// <param name="bodyStream">The content to be encrypted.</param>
-        /// <param name="messageType">The message type, <see cref="UaTcpMessageTypes"/>.</param>
+        /// <param name="messageType">The message type, <see cref="MessageTypes"/>.</param>
         /// <param name="requestHandle">The request handle.</param>
         /// <param name="consume">The delegate to consume the encrypted chunks.</param>
         /// <param name="token">A cancellation token used to propagate notification that this operation should be canceled.</param>

--- a/UaClient/ServiceModel/Ua/SubscriptionBase.cs
+++ b/UaClient/ServiceModel/Ua/SubscriptionBase.cs
@@ -27,13 +27,13 @@ namespace Workstation.ServiceModel.Ua
         private readonly ILogger? logger;
         private readonly UaApplication application;
         private volatile bool isPublishing;
-        private volatile UaTcpSessionChannel? innerChannel;
+        private volatile ClientSessionChannel? innerChannel;
         private volatile uint subscriptionId;
         private readonly ErrorsContainer<string> errors;
         private PropertyChangedEventHandler? propertyChanged;
         private readonly string? endpointUrl;
-        private readonly double publishingInterval = UaTcpSessionChannel.DefaultPublishingInterval;
-        private readonly uint keepAliveCount = UaTcpSessionChannel.DefaultKeepaliveCount;
+        private readonly double publishingInterval = ClientSessionChannel.DefaultPublishingInterval;
+        private readonly uint keepAliveCount = ClientSessionChannel.DefaultKeepaliveCount;
         private readonly uint lifetimeCount;
         private readonly MonitoredItemBaseCollection monitoredItems = new MonitoredItemBaseCollection();
         private CommunicationState state = CommunicationState.Created;
@@ -287,7 +287,7 @@ namespace Workstation.ServiceModel.Ua
         /// <summary>
         /// Gets the inner channel.
         /// </summary>
-        protected UaTcpSessionChannel InnerChannel
+        protected ClientSessionChannel InnerChannel
         {
             get
             {
@@ -495,7 +495,7 @@ namespace Workstation.ServiceModel.Ua
         /// <param name="channel">The session channel. </param>
         /// <param name="token">A cancellation token. </param>
         /// <returns>A task.</returns>
-        private async Task WhenChannelClosingAsync(UaTcpSessionChannel channel, CancellationToken token = default)
+        private async Task WhenChannelClosingAsync(ClientSessionChannel channel, CancellationToken token = default)
         {
             var tcs = new TaskCompletionSource<bool>();
             EventHandler handler = (o, e) =>

--- a/UaClient/ServiceModel/Ua/TransportConnectionOptions.cs
+++ b/UaClient/ServiceModel/Ua/TransportConnectionOptions.cs
@@ -1,0 +1,35 @@
+﻿// Copyright (c) Converter Systems LLC. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Workstation.ServiceModel.Ua
+{
+    /// <summary>
+    /// The transport connection options.
+    /// </summary>
+    public class TransportConnectionOptions
+    {
+        public const uint DefaultBufferSize = 64 * 1024;
+        public const uint DefaultMaxMessageSize = 16 * 1024 * 1024;
+        public const uint DefaultMaxChunkCount = 4 * 1024;
+
+        /// <summary>
+        /// Gets or sets the size of the receive buffer.
+        /// </summary>
+        public uint ReceiveBufferSize { get; set; } = DefaultBufferSize;
+
+        /// <summary>
+        /// Gets or sets the size of the send buffer.
+        /// </summary>
+        public uint SendBufferSize { get; set; } = DefaultBufferSize;
+
+        /// <summary>
+        /// Gets or sets the maximum total size of a message.
+        /// </summary>
+        public uint MaxMessageSize { get; set; } = DefaultMaxMessageSize;
+
+        /// <summary>
+        /// Gets or sets the maximum number of message chunks.
+        /// </summary>
+        public uint MaxChunkCount { get; set; } = DefaultMaxChunkCount;
+    }
+}

--- a/UaClient/ServiceModel/Ua/UaApplication.cs
+++ b/UaClient/ServiceModel/Ua/UaApplication.cs
@@ -203,7 +203,7 @@ namespace Workstation.ServiceModel.Ua
         /// <returns>A <see cref="ClientSessionChannel"/>.</returns>
         public async Task<ClientSessionChannel> GetChannelAsync(string endpointUrl, CancellationToken token = default)
         {
-            this.logger?.LogTrace($"Begin getting UaTcpSessionChannel for {endpointUrl}");
+            this.logger?.LogTrace($"Begin getting {nameof(ClientSessionChannel)} for {endpointUrl}");
             if (string.IsNullOrEmpty(endpointUrl))
             {
                 throw new ArgumentNullException(nameof(endpointUrl));
@@ -223,7 +223,7 @@ namespace Workstation.ServiceModel.Ua
         {
             try
             {
-                this.logger?.LogTrace($"Begin creating UaTcpSessionChannel for {endpointUrl}");
+                this.logger?.LogTrace($"Begin creating {nameof(ClientSessionChannel)} for {endpointUrl}");
                 await this.CheckSuspension(token).ConfigureAwait(false);
 
                 EndpointDescription endpoint;
@@ -247,7 +247,7 @@ namespace Workstation.ServiceModel.Ua
 
                 channel.Faulted += (s, e) =>
                 {
-                    this.logger?.LogTrace($"Error creating UaTcpSessionChannel for {endpointUrl}. OnFaulted");
+                    this.logger?.LogTrace($"Error creating {nameof(ClientSessionChannel)} for {endpointUrl}. OnFaulted");
                     var ch = (ClientSessionChannel)s!;
                     try
                     {
@@ -260,18 +260,18 @@ namespace Workstation.ServiceModel.Ua
 
                 channel.Closing += (s, e) =>
                 {
-                    this.logger?.LogTrace($"Removing UaTcpSessionChannel for {endpointUrl} from channelMap.");
+                    this.logger?.LogTrace($"Removing {nameof(ClientSessionChannel)} for {endpointUrl} from channelMap.");
                     this.channelMap.TryRemove(endpointUrl, out _);
                 };
 
                 await channel.OpenAsync(token).ConfigureAwait(false);
-                this.logger?.LogTrace($"Success creating UaTcpSessionChannel for {endpointUrl}.");
+                this.logger?.LogTrace($"Success creating {nameof(ClientSessionChannel)} for {endpointUrl}.");
                 return channel;
 
             }
             catch (Exception ex)
             {
-                this.logger?.LogTrace($"Error creating UaTcpSessionChannel for {endpointUrl}. {ex.Message}");
+                this.logger?.LogTrace($"Error creating {nameof(ClientSessionChannel)} for {endpointUrl}. {ex.Message}");
                 throw;
             }
         }

--- a/UaClient/ServiceModel/Ua/UaApplicationOptions.cs
+++ b/UaClient/ServiceModel/Ua/UaApplicationOptions.cs
@@ -12,61 +12,61 @@ namespace Workstation.ServiceModel.Ua
     /// <summary>
     /// The UaApplication options.
     /// </summary>
-    public class UaApplicationOptions : UaTcpSessionChannelOptions
+    public class UaApplicationOptions : ClientSessionChannelOptions
     {
     }
 
     /// <summary>
-    /// The UaTcpSessionChannel options.
+    /// The <see cref="ClientSessionChannel"/> options.
     /// </summary>
-    public class UaTcpSessionChannelOptions : UaTcpSecureChannelOptions
+    public class ClientSessionChannelOptions : ClientSecureChannelOptions
     {
         /// <summary>
         /// Gets the requested number of milliseconds that a session may be unused before being closed by the server.
         /// </summary>
-        public double SessionTimeout { get; set; } = UaTcpSessionChannel.DefaultSessionTimeout;
+        public double SessionTimeout { get; set; } = ClientSessionChannel.DefaultSessionTimeout;
     }
 
     /// <summary>
-    /// The UaTcpSecureChannel options.
+    /// The <see cref="ClientSecureChannel"/> options.
     /// </summary>
-    public class UaTcpSecureChannelOptions : UaTcpTransportChannelOptions
+    public class ClientSecureChannelOptions : ClientTransportChannelOptions
     {
         /// <summary>
         /// Gets or sets the default number of milliseconds that may elapse before an operation is cancelled by the service.
         /// </summary>
-        public uint TimeoutHint { get; set; } = UaTcpSecureChannel.DefaultTimeoutHint;
+        public uint TimeoutHint { get; set; } = ClientSecureChannel.DefaultTimeoutHint;
 
         /// <summary>
         /// Gets or sets the default diagnostics flags to be requested by the service.
         /// </summary>
-        public uint DiagnosticsHint { get; set; } = UaTcpSecureChannel.DefaultDiagnosticsHint;
+        public uint DiagnosticsHint { get; set; } = ClientSecureChannel.DefaultDiagnosticsHint;
     }
 
     /// <summary>
-    /// The UaTcpTransportChannel options.
+    /// The <see cref="ClientTransportChannel"/> options.
     /// </summary>
-    public class UaTcpTransportChannelOptions
+    public class ClientTransportChannelOptions
     {
         /// <summary>
         /// Gets or sets the size of the receive buffer.
         /// </summary>
-        public uint LocalReceiveBufferSize { get; set; } = UaTcpTransportChannel.DefaultBufferSize;
+        public uint LocalReceiveBufferSize { get; set; } = ClientTransportChannel.DefaultBufferSize;
 
         /// <summary>
         /// Gets or sets the size of the send buffer.
         /// </summary>
-        public uint LocalSendBufferSize { get; set; } = UaTcpTransportChannel.DefaultBufferSize;
+        public uint LocalSendBufferSize { get; set; } = ClientTransportChannel.DefaultBufferSize;
 
         /// <summary>
         /// Gets or sets the maximum total size of a message.
         /// </summary>
-        public uint LocalMaxMessageSize { get; set; } = UaTcpTransportChannel.DefaultMaxMessageSize;
+        public uint LocalMaxMessageSize { get; set; } = ClientTransportChannel.DefaultMaxMessageSize;
 
         /// <summary>
         /// Gets or sets the maximum number of message chunks.
         /// </summary>
-        public uint LocalMaxChunkCount { get; set; } = UaTcpTransportChannel.DefaultMaxChunkCount;
+        public uint LocalMaxChunkCount { get; set; } = ClientTransportChannel.DefaultMaxChunkCount;
     }
 
     /// <summary>

--- a/UaClient/ServiceModel/Ua/UaApplicationOptions.cs
+++ b/UaClient/ServiceModel/Ua/UaApplicationOptions.cs
@@ -68,34 +68,4 @@ namespace Workstation.ServiceModel.Ua
         /// </summary>
         public uint LocalMaxChunkCount { get; set; } = ClientTransportChannel.DefaultMaxChunkCount;
     }
-
-    /// <summary>
-    /// The transport connection options.
-    /// </summary>
-    public class TransportConnectionOptions
-    {
-        public const uint DefaultBufferSize = 64 * 1024;
-        public const uint DefaultMaxMessageSize = 16 * 1024 * 1024;
-        public const uint DefaultMaxChunkCount = 4 * 1024;
-
-        /// <summary>
-        /// Gets or sets the size of the receive buffer.
-        /// </summary>
-        public uint ReceiveBufferSize { get; set; } = DefaultBufferSize;
-
-        /// <summary>
-        /// Gets or sets the size of the send buffer.
-        /// </summary>
-        public uint SendBufferSize { get; set; } = DefaultBufferSize;
-
-        /// <summary>
-        /// Gets or sets the maximum total size of a message.
-        /// </summary>
-        public uint MaxMessageSize { get; set; } = DefaultMaxMessageSize;
-
-        /// <summary>
-        /// Gets or sets the maximum number of message chunks.
-        /// </summary>
-        public uint MaxChunkCount { get; set; } = DefaultMaxChunkCount;
-    }
 }


### PR DESCRIPTION
This is the last PR in this series. One can now inject the stack profile with the channel constructor. As fallback the stack profile will be determine by the `EndpointDescription`. At the moment `StackProfiles.GetStackProfile()` only returns the `TcpUascBinary` stack. Since the channels can now (theoretically) handle other profiles, they are renamed, e.g., `UaTcpXxxChannel` to `ClientXxxChannel`.