### PR TITLE
StackProfile part 6: Addendum

### DIFF
--- a/UaClient.UnitTests/TestCertificateStore.cs
+++ b/UaClient.UnitTests/TestCertificateStore.cs
@@ -9,6 +9,7 @@ using Org.BouncyCastle.Security;
 using Org.BouncyCastle.X509;
 using System;
 using System.Linq;
+using System.Threading;
 using System.Threading.Tasks;
 using Workstation.ServiceModel.Ua;
 
@@ -41,7 +42,7 @@ namespace Workstation.UaClient
             ClientCertificate = _clientCertificate.GetEncoded();
         }
 
-        public Task<(X509Certificate Certificate, RsaKeyParameters Key)> GetLocalCertificateAsync(ApplicationDescription applicationDescription, ILogger logger)
+        public Task<(X509Certificate Certificate, RsaKeyParameters Key)> GetLocalCertificateAsync(ApplicationDescription applicationDescription, ILogger logger, CancellationToken token)
         {
             if (applicationDescription.ApplicationName == _serverDescription.ApplicationName)
             {
@@ -55,7 +56,7 @@ namespace Workstation.UaClient
             throw new InvalidOperationException();
         }
 
-        public Task<bool> ValidateRemoteCertificateAsync(X509Certificate certificate, ILogger logger)
+        public Task<bool> ValidateRemoteCertificateAsync(X509Certificate certificate, ILogger logger, CancellationToken token)
         {
             var cert = certificate.GetEncoded();
             var valid = cert.SequenceEqual(ServerCertificate)

--- a/UaClient.UnitTests/ThrowingTestCertificateStore.cs
+++ b/UaClient.UnitTests/ThrowingTestCertificateStore.cs
@@ -2,6 +2,7 @@
 using Org.BouncyCastle.Crypto.Parameters;
 using Org.BouncyCastle.X509;
 using System;
+using System.Threading;
 using System.Threading.Tasks;
 using Workstation.ServiceModel.Ua;
 
@@ -13,10 +14,10 @@ namespace Workstation.UaClient
 
         public byte[] ClientCertificate => null;
 
-        public Task<(X509Certificate Certificate, RsaKeyParameters Key)> GetLocalCertificateAsync(ApplicationDescription applicationDescription, ILogger logger)
+        public Task<(X509Certificate Certificate, RsaKeyParameters Key)> GetLocalCertificateAsync(ApplicationDescription applicationDescription, ILogger logger, CancellationToken token)
             => throw new NotImplementedException();
 
-        public Task<bool> ValidateRemoteCertificateAsync(X509Certificate certificate, ILogger logger)
+        public Task<bool> ValidateRemoteCertificateAsync(X509Certificate certificate, ILogger logger, CancellationToken token)
             => throw new NotImplementedException();
     }
 }

--- a/UaClient.UnitTests/UnitTests/Channels/UaSecureConversationTests.cs
+++ b/UaClient.UnitTests/UnitTests/Channels/UaSecureConversationTests.cs
@@ -341,7 +341,7 @@ namespace Workstation.UaClient.UnitTests.Channels
                 SecurityMode = mode,
             };
 
-            await client.SetRemoteCertificateAsync(securityPolicyUri, store.ServerCertificate);
+            await client.SetRemoteCertificateAsync(securityPolicyUri, store.ServerCertificate, default);
             return client;
         }
 

--- a/UaClient.UnitTests/coverlet.runsettings
+++ b/UaClient.UnitTests/coverlet.runsettings
@@ -5,7 +5,7 @@
       <DataCollector friendlyName="XPlat code coverage">
         <Configuration>
           <Format>json,cobertura</Format>
-          <ExcludeByAttribute>ObsoleteAttribute,GeneratedCodeAttribute,CompilerGeneratedAttribute</ExcludeByAttribute>
+          <ExcludeByAttribute>ObsoleteAttribute,GeneratedCodeAttribute</ExcludeByAttribute>
           <ExcludeByFile>**\*.generated.cs</ExcludeByFile> <!-- Absolute or relative file paths -->
           <SingleHit>false</SingleHit>
           <UseSourceLink>true</UseSourceLink>

--- a/UaClient/ServiceModel/Ua/Channels/ClientSecureChannel.cs
+++ b/UaClient/ServiceModel/Ua/Channels/ClientSecureChannel.cs
@@ -179,7 +179,7 @@ namespace Workstation.ServiceModel.Ua.Channels
                 MaxChunkCount = RemoteMaxChunkCount
             };
 
-            _conversation = await StackProfile.ConversationProvider.CreateAsync(RemoteEndpoint, LocalDescription, options, CertificateStore, _logger).ConfigureAwait(false);
+            _conversation = await StackProfile.ConversationProvider.CreateAsync(RemoteEndpoint, LocalDescription, options, CertificateStore, _logger, token).ConfigureAwait(false);
 
             token.ThrowIfCancellationRequested();
 

--- a/UaClient/ServiceModel/Ua/Channels/ClientSessionChannel.cs
+++ b/UaClient/ServiceModel/Ua/Channels/ClientSessionChannel.cs
@@ -339,7 +339,7 @@ namespace Workstation.ServiceModel.Ua.Channels
 
                 if (CertificateStore != null)
                 {
-                    var tuple = await CertificateStore.GetLocalCertificateAsync(LocalDescription, _logger);
+                    var tuple = await CertificateStore.GetLocalCertificateAsync(LocalDescription, _logger, token);
                     LocalCertificate = tuple.Certificate?.GetEncoded();
                     LocalPrivateKey = tuple.Key;
                 }

--- a/UaClient/ServiceModel/Ua/Channels/ClientTransportChannel.cs
+++ b/UaClient/ServiceModel/Ua/Channels/ClientTransportChannel.cs
@@ -131,7 +131,7 @@ namespace Workstation.ServiceModel.Ua.Channels
         {
             token.ThrowIfCancellationRequested();
 
-            _connection = await StackProfile.TransportConnectionProvider.ConnectAsync(RemoteEndpoint.EndpointUrl!).ConfigureAwait(false);
+            _connection = await StackProfile.TransportConnectionProvider.ConnectAsync(RemoteEndpoint.EndpointUrl!, token).ConfigureAwait(false);
 
             var localOptions = new TransportConnectionOptions
             {

--- a/UaClient/ServiceModel/Ua/Channels/UaSecureConversation.cs
+++ b/UaClient/ServiceModel/Ua/Channels/UaSecureConversation.cs
@@ -172,7 +172,7 @@ namespace Workstation.ServiceModel.Ua.Channels
         /// <param name="securityPolicyUri">The security policy URI.</param>
         /// <param name="remoteCertificate">The remote certificate.</param>
         /// <returns>A task representing the asynchronous operation.</returns>
-        public async Task SetRemoteCertificateAsync(string? securityPolicyUri, byte[]? remoteCertificate)
+        public async Task SetRemoteCertificateAsync(string? securityPolicyUri, byte[]? remoteCertificate, CancellationToken token)
         {
             _securityPolicyUri = securityPolicyUri;
             _remoteCertificate = remoteCertificate;
@@ -184,7 +184,7 @@ namespace Workstation.ServiceModel.Ua.Channels
                 {
                     if (_certificateStore != null)
                     {
-                        var result = await _certificateStore.ValidateRemoteCertificateAsync(cert, _logger);
+                        var result = await _certificateStore.ValidateRemoteCertificateAsync(cert, _logger, token);
                         if (!result)
                         {
                             throw new ServiceResultException(StatusCodes.BadSecurityChecksFailed, "Remote certificate is untrusted.");
@@ -217,7 +217,7 @@ namespace Workstation.ServiceModel.Ua.Channels
             {
                 if (_localCertificate == null && _certificateStore != null)
                 {
-                    var tuple = await _certificateStore.GetLocalCertificateAsync(_localDescription, _logger);
+                    var tuple = await _certificateStore.GetLocalCertificateAsync(_localDescription, _logger, token);
                     _localCertificate = tuple.Certificate?.GetEncoded();
                     _localPrivateKey = tuple.Key;
                 }
@@ -827,7 +827,7 @@ namespace Workstation.ServiceModel.Ua.Channels
 
                             if (IsServer)
                             {
-                                await SetRemoteCertificateAsync(securityPolicyUri, remoteCertificate).ConfigureAwait(false);
+                                await SetRemoteCertificateAsync(securityPolicyUri, remoteCertificate, token).ConfigureAwait(false);
                             }
 
                             plainHeaderSize = decoder.Position;

--- a/UaClient/ServiceModel/Ua/Channels/UaSecureConversationProvider.cs
+++ b/UaClient/ServiceModel/Ua/Channels/UaSecureConversationProvider.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.Extensions.Logging;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace Workstation.ServiceModel.Ua.Channels
@@ -14,14 +15,14 @@ namespace Workstation.ServiceModel.Ua.Channels
     public class UaSecureConversationProvider : IConversationProvider
     {
         /// <inheritdoc />
-        public async Task<IConversation> CreateAsync(EndpointDescription remoteEndpoint, ApplicationDescription localDescription, TransportConnectionOptions options, ICertificateStore? certificateStore, ILogger? logger)
+        public async Task<IConversation> CreateAsync(EndpointDescription remoteEndpoint, ApplicationDescription localDescription, TransportConnectionOptions options, ICertificateStore? certificateStore, ILogger? logger, CancellationToken token)
         {
             var conversation = new UaSecureConversation(localDescription, options, certificateStore, logger)
             {
                 SecurityMode = remoteEndpoint.SecurityMode
             };
 
-            await conversation.SetRemoteCertificateAsync(remoteEndpoint.SecurityPolicyUri, remoteEndpoint.ServerCertificate).ConfigureAwait(false);
+            await conversation.SetRemoteCertificateAsync(remoteEndpoint.SecurityPolicyUri, remoteEndpoint.ServerCertificate, token).ConfigureAwait(false);
 
             return conversation;
         }

--- a/UaClient/ServiceModel/Ua/Channels/UaTcpConnectionProvider.cs
+++ b/UaClient/ServiceModel/Ua/Channels/UaTcpConnectionProvider.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Net.Sockets;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace Workstation.ServiceModel.Ua.Channels
@@ -17,7 +18,7 @@ namespace Workstation.ServiceModel.Ua.Channels
         private const int ConnectTimeout = 5000;
 
         /// <inheritdoc />
-        public async Task<ITransportConnection> ConnectAsync(string connectionString)
+        public async Task<ITransportConnection> ConnectAsync(string connectionString, CancellationToken token)
         {
             var uri = new Uri(connectionString);
             var client = new TcpClient
@@ -25,7 +26,7 @@ namespace Workstation.ServiceModel.Ua.Channels
                 NoDelay = true
             };
 
-            await client.ConnectAsync(uri.Host, uri.Port).TimeoutAfter(ConnectTimeout).ConfigureAwait(false);
+            await client.ConnectAsync(uri.Host, uri.Port).TimeoutAfter(ConnectTimeout, token).ConfigureAwait(false);
 
             // The stream will own the client and takes care on disposing/closing it
             return new UaClientConnection(client.GetStream(), uri);

--- a/UaClient/ServiceModel/Ua/DirectoryStore.cs
+++ b/UaClient/ServiceModel/Ua/DirectoryStore.cs
@@ -4,6 +4,7 @@
 using System;
 using System.IO;
 using System.Linq;
+using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
 using Org.BouncyCastle.Asn1.X509;
@@ -60,7 +61,7 @@ namespace Workstation.ServiceModel.Ua
         public bool CreateLocalCertificateIfNotExist { get; }
 
         /// <inheritdoc/>
-        public async Task<(X509Certificate? Certificate, RsaKeyParameters? Key)> GetLocalCertificateAsync(ApplicationDescription applicationDescription, ILogger? logger = null)
+        public async Task<(X509Certificate? Certificate, RsaKeyParameters? Key)> GetLocalCertificateAsync(ApplicationDescription applicationDescription, ILogger? logger = null, CancellationToken token = default)
         {
             if (applicationDescription == null)
             {
@@ -266,7 +267,7 @@ namespace Workstation.ServiceModel.Ua
         }
 
         /// <inheritdoc/>
-        public Task<bool> ValidateRemoteCertificateAsync(X509Certificate target, ILogger? logger = null)
+        public Task<bool> ValidateRemoteCertificateAsync(X509Certificate target, ILogger? logger = null, CancellationToken token = default)
         {
             if (AcceptAllRemoteCertificates)
             {

--- a/UaClient/ServiceModel/Ua/ICertificateStore.cs
+++ b/UaClient/ServiceModel/Ua/ICertificateStore.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
+using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
 using Org.BouncyCastle.Crypto.Parameters;
@@ -20,7 +21,7 @@ namespace Workstation.ServiceModel.Ua
         /// <param name="applicationDescription">The application description.</param>
         /// <param name="logger">The logger.</param>
         /// <returns>The local certificate and private key.</returns>
-        Task<(X509Certificate? Certificate, RsaKeyParameters? Key)> GetLocalCertificateAsync(ApplicationDescription applicationDescription, ILogger? logger);
+        Task<(X509Certificate? Certificate, RsaKeyParameters? Key)> GetLocalCertificateAsync(ApplicationDescription applicationDescription, ILogger? logger, System.Threading.CancellationToken token);
 
         /// <summary>
         /// Validates the remote certificate.
@@ -28,6 +29,6 @@ namespace Workstation.ServiceModel.Ua
         /// <param name="certificate">The remote certificate.</param>
         /// <param name="logger">The logger.</param>
         /// <returns>The validator result.</returns>
-        Task<bool> ValidateRemoteCertificateAsync(X509Certificate certificate, ILogger? logger);
+        Task<bool> ValidateRemoteCertificateAsync(X509Certificate certificate, ILogger? logger, CancellationToken token);
     }
 }

--- a/UaClient/ServiceModel/Ua/IConversationProvider.cs
+++ b/UaClient/ServiceModel/Ua/IConversationProvider.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.Extensions.Logging;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace Workstation.ServiceModel.Ua
@@ -21,6 +22,6 @@ namespace Workstation.ServiceModel.Ua
         /// <param name="certificateStore">The certificate store.</param>
         /// <param name="logger">The logger.</param>
         /// <returns>An <see cref="IConversation"/> instance.</returns>
-        Task<IConversation> CreateAsync(EndpointDescription remoteEndpoint, ApplicationDescription localDescription, TransportConnectionOptions options, ICertificateStore? certificateStore, ILogger? logger);
+        Task<IConversation> CreateAsync(EndpointDescription remoteEndpoint, ApplicationDescription localDescription, TransportConnectionOptions options, ICertificateStore? certificateStore, ILogger? logger, CancellationToken token);
     }
 }

--- a/UaClient/ServiceModel/Ua/ITransportConnectionProvider.cs
+++ b/UaClient/ServiceModel/Ua/ITransportConnectionProvider.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Converter Systems LLC. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace Workstation.ServiceModel.Ua
@@ -20,6 +21,6 @@ namespace Workstation.ServiceModel.Ua
         /// </remarks>
         /// <param name="connectionString">The connection string.</param>
         /// <returns>The transport connection.</returns>
-        Task<ITransportConnection> ConnectAsync(string connectionString);
+        Task<ITransportConnection> ConnectAsync(string connectionString, CancellationToken token);
     }
 }


### PR DESCRIPTION
In the last PR, I said it would be the last one in this series. But I forgot one important point. The factory methods (`IConversationProvider.CreateAsync` and `ITransportConnectionProvider.ConnectAsync`) should take a cancellation token as argument.