### PR TITLE
upgrade to .NET6, Improve logging and handle CreateSessionResponse with handle of "0"

### DIFF
--- a/UaClient/ServiceModel/Ua/Channels/ClientSessionChannel.cs
+++ b/UaClient/ServiceModel/Ua/Channels/ClientSessionChannel.cs
@@ -270,7 +270,7 @@ namespace Workstation.ServiceModel.Ua.Channels
                 var securityPolicyUri = RemoteEndpoint.SecurityPolicyUri;
                 try
                 {
-                    _logger?.LogInformation($"Discovering endpoints of '{endpointUrl}'.");
+                    _logger?.LogInformation("Discovering endpoints of '{endpointUrl}'.", endpointUrl);
                     var getEndpointsRequest = new GetEndpointsRequest
                     {
                         EndpointUrl = endpointUrl,
@@ -301,11 +301,11 @@ namespace Workstation.ServiceModel.Ua.Channels
                     RemoteEndpoint.TransportProfileUri = selectedEndpoint.TransportProfileUri;
                     RemoteEndpoint.SecurityLevel = selectedEndpoint.SecurityLevel;
 
-                    _logger?.LogTrace($"Success discovering endpoints of '{endpointUrl}'.");
+                    _logger?.LogTrace("Success discovering endpoints of '{endpointUrl}'.", endpointUrl);
                 }
                 catch (Exception ex)
                 {
-                    _logger?.LogError($"Error discovering endpoints of '{endpointUrl}'. {ex.Message}");
+                    _logger?.LogError(ex, "Error discovering endpoints of '{endpointUrl}'.", endpointUrl);
                     throw;
                 }
             }
@@ -322,10 +322,10 @@ namespace Workstation.ServiceModel.Ua.Channels
         /// <inheritdoc/>
         protected override async Task OnOpenAsync(CancellationToken token = default)
         {
-            _logger?.LogInformation($"Opening session channel with endpoint '{RemoteEndpoint.EndpointUrl}'.");
-            _logger?.LogInformation($"SecurityPolicy: '{RemoteEndpoint.SecurityPolicyUri}'.");
-            _logger?.LogInformation($"SecurityMode: '{RemoteEndpoint.SecurityMode}'.");
-            _logger?.LogInformation($"UserIdentity: '{UserIdentity}'.");
+            _logger?.LogInformation("Opening session channel with endpoint '{RemoteEndpoint.EndpointUrl}'.", RemoteEndpoint.EndpointUrl);
+            _logger?.LogInformation("SecurityPolicy: '{RemoteEndpoint.SecurityPolicyUri}'.", RemoteEndpoint.SecurityPolicyUri);
+            _logger?.LogInformation("SecurityMode: '{RemoteEndpoint.SecurityMode}'.", RemoteEndpoint.SecurityMode);
+            _logger?.LogInformation("UserIdentity: '{UserIdentity}'.", UserIdentity);
 
             await base.OnOpenAsync(token).ConfigureAwait(false);
 
@@ -847,7 +847,7 @@ namespace Workstation.ServiceModel.Ua.Channels
                         return;
                     }
 
-                    _logger?.LogError($"Error publishing subscription. {ex.Message}");
+                    _logger?.LogError(ex, "Error publishing subscription. {publishRequest}", publishRequest);
                     Fault(ex);
                     return;
                 }

--- a/UaClient/ServiceModel/Ua/Channels/CommunicationObject.cs
+++ b/UaClient/ServiceModel/Ua/Channels/CommunicationObject.cs
@@ -162,7 +162,7 @@ namespace Workstation.ServiceModel.Ua.Channels
                         {
                             if (flag2)
                             {
-                                _logger?.LogError($"Error closing channel.");
+                                _logger?.LogError("Error closing channel.");
                                 await AbortAsync(token).ConfigureAwait(false);
                             }
                         }
@@ -299,7 +299,7 @@ namespace Workstation.ServiceModel.Ua.Channels
                 _semaphore.Release();
             }
 
-            _logger?.LogTrace($"Channel closed.");
+            _logger?.LogTrace("Channel closed.");
             EventHandler? closed = Closed;
             if (closed != null)
             {
@@ -330,7 +330,7 @@ namespace Workstation.ServiceModel.Ua.Channels
                 _semaphore.Release();
             }
 
-            _logger?.LogTrace($"Channel closing.");
+            _logger?.LogTrace("Channel closing.");
             EventHandler? closing = Closing;
             if (closing != null)
             {
@@ -360,7 +360,7 @@ namespace Workstation.ServiceModel.Ua.Channels
                 _semaphore.Release();
             }
 
-            _logger?.LogTrace($"Channel faulted.");
+            _logger?.LogTrace("Channel faulted.");
             EventHandler? faulted = Faulted;
             if (faulted != null)
             {
@@ -398,7 +398,7 @@ namespace Workstation.ServiceModel.Ua.Channels
                 _semaphore.Release();
             }
 
-            _logger?.LogTrace($"Channel opened.");
+            _logger?.LogTrace("Channel opened.");
             EventHandler? opened = Opened;
             if (opened != null)
             {
@@ -423,7 +423,7 @@ namespace Workstation.ServiceModel.Ua.Channels
                 _semaphore.Release();
             }
 
-            _logger?.LogTrace($"Channel opening.");
+            _logger?.LogTrace("Channel opening.");
             EventHandler? opening = Opening;
             if (opening != null)
             {

--- a/UaClient/ServiceModel/Ua/Channels/UaSecureConversation.cs
+++ b/UaClient/ServiceModel/Ua/Channels/UaSecureConversation.cs
@@ -744,7 +744,7 @@ namespace Workstation.ServiceModel.Ua.Channels
                                     }
                                 }
 
-                                _logger?.LogTrace($"Installed new security token {tokenId}.");
+                                _logger?.LogTrace("Installed new security token {tokenId}.", tokenId);
                             }
 
                             var plainHeaderSize = decoder.Position;

--- a/UaClient/ServiceModel/Ua/Channels/UaSecureConversation.cs
+++ b/UaClient/ServiceModel/Ua/Channels/UaSecureConversation.cs
@@ -179,7 +179,7 @@ namespace Workstation.ServiceModel.Ua.Channels
 
             if (remoteCertificate != null)
             {
-                var cert = _certificateParser.ReadCertificate(remoteCertificate);
+                var cert = (remoteCertificate?.Length ?? 0) > 0 ? _certificateParser.ReadCertificate(remoteCertificate) : null;
                 if (cert != null)
                 {
                     if (_certificateStore != null)

--- a/UaClient/ServiceModel/Ua/Channels/UaTcpConnectionProvider.cs
+++ b/UaClient/ServiceModel/Ua/Channels/UaTcpConnectionProvider.cs
@@ -15,7 +15,10 @@ namespace Workstation.ServiceModel.Ua.Channels
     /// <seealso href="https://reference.opcfoundation.org/v104/Core/docs/Part6/7.2/">OPC UA specification Part 6: Mappings, 7.2</seealso>
     public class UaTcpConnectionProvider : ITransportConnectionProvider
     {
-        private const int ConnectTimeout = 5000;
+        /// <summary>
+        /// Connection timeout defaults to 5.0s
+        /// </summary>
+        public static int ConnectTimeout = 5000;
 
         /// <inheritdoc />
         public async Task<ITransportConnection> ConnectAsync(string connectionString, CancellationToken token)

--- a/UaClient/Workstation.UaClient.csproj
+++ b/UaClient/Workstation.UaClient.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks>net6.0</TargetFrameworks>
     <AssemblyName>Workstation.UaClient</AssemblyName>
     <RootNamespace>Workstation</RootNamespace>
     <Version>3.1.1</Version>
@@ -35,14 +35,14 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.IO.RecyclableMemoryStream" Version="2.0.0" />
-    <PackageReference Include="Portable.BouncyCastle" Version="1.8.10" />
+    <PackageReference Include="Microsoft.IO.RecyclableMemoryStream" Version="2.2.1" />
+    <PackageReference Include="Portable.BouncyCastle" Version="1.9.0" />
     <PackageReference Include="System.Reactive" Version="5.0.0" />
-    <PackageReference Include="System.Threading.Tasks.Dataflow" Version="5.0.0" />
+    <PackageReference Include="System.Threading.Tasks.Dataflow" Version="6.0.0" />
     <PackageReference Include="System.ValueTuple" Version="4.5.0" />
-    <PackageReference Include="Microsoft.Extensions.Logging" Version="5.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="5.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="5.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging" Version="6.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="6.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="6.0.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/UaClient/Workstation.UaClient.csproj
+++ b/UaClient/Workstation.UaClient.csproj
@@ -4,7 +4,7 @@
     <TargetFrameworks>net6.0</TargetFrameworks>
     <AssemblyName>Workstation.UaClient</AssemblyName>
     <RootNamespace>Workstation</RootNamespace>
-    <Version>3.1.1</Version>
+    <Version>3.1.2</Version>
     <Authors>Andrew Cullen</Authors>
     <Company>Converter Systems LLC</Company>
     <PackageProjectUrl>https://github.com/convertersystems/opc-ua-client</PackageProjectUrl>
@@ -13,10 +13,10 @@
     <PackageTags>opc, opc-ua, iiot</PackageTags>
     <RepositoryUrl>https://github.com/convertersystems/opc-ua-client</RepositoryUrl>
     <Copyright>Copyright ©  2021 Converter Systems LLC.</Copyright>
-    <AssemblyVersion>3.1.1.0</AssemblyVersion>
+    <AssemblyVersion>3.1.2.0</AssemblyVersion>
     <AssemblyTitle>Workstation.UaClient ($(TargetFramework))</AssemblyTitle>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-    <FileVersion>3.1.1.0</FileVersion>
+    <FileVersion>3.1.2.0</FileVersion>
     <SignAssembly>True</SignAssembly>
     <AssemblyOriginatorKeyFile>Key.snk</AssemblyOriginatorKeyFile>
     <IncludeSymbols>true</IncludeSymbols>


### PR DESCRIPTION
- improve logging by using named log values (this creates named values, that are better suitable for filtering)
- handle responses with Handle 0 also for the case of CreateSessionResponse/CreateSessionRequest
- upgrade to .NET 6
- fix a NullReferenceException, when the RemoteCertificate is null