### PR TITLE
forward internal errors instead of timeout status codes

### DIFF
--- a/UaClient/ServiceModel/Ua/Channels/CommunicationObject.cs
+++ b/UaClient/ServiceModel/Ua/Channels/CommunicationObject.cs
@@ -436,6 +436,16 @@ namespace Workstation.ServiceModel.Ua.Channels
             _exceptions.Value.Enqueue(exception);
         }
 
+        protected Exception? PeakFirstPendingException()
+        {
+            if (_exceptions.Value.TryPeek(out var ex))
+            {
+                return ex;
+            }
+
+            return null;
+        }
+
         protected Exception? GetPendingException()
         {
             if (_exceptions.Value.TryDequeue(out var ex))


### PR DESCRIPTION
Fixes https://github.com/convertersystems/opc-ua-client/issues/236

The only question for me is should we leave the _exception list filled with the exception or can we consume it.