### PR TITLE
Get all properties that marked with MonitoredItemAttribute including from base class

### DIFF
--- a/UaClient/ServiceModel/Ua/SubscriptionBase.cs
+++ b/UaClient/ServiceModel/Ua/SubscriptionBase.cs
@@ -88,7 +88,7 @@ namespace Workstation.ServiceModel.Ua
             }
 
             // read [MonitoredItem] attributes.
-            foreach (var propertyInfo in typeInfo.DeclaredProperties)
+            foreach (var propertyInfo in typeInfo.GetProperties().Where(p => p.GetCustomAttribute<MonitoredItemAttribute>() != null))
             {
                 var mia = propertyInfo.GetCustomAttribute<MonitoredItemAttribute>();
                 if (mia == null || string.IsNullOrEmpty(mia.NodeId))


### PR DESCRIPTION
Get all properties that marked with MonitoredItemAttribute including from base class instead of DeclaredProperties only to make MonitoredItem from base class also work.