### PR TITLE
Make TypeLibrary type parsing more resilient

### DIFF
--- a/UaClient/ServiceModel/Ua/TypeLibrary.cs
+++ b/UaClient/ServiceModel/Ua/TypeLibrary.cs
@@ -94,23 +94,30 @@ namespace Workstation.ServiceModel.Ua
         {
             foreach (var type in assembly.GetExportedTypes())
             {
-                var attr = type.GetCustomAttribute<BinaryEncodingIdAttribute>(false);
-                if (attr != null)
+                try 
                 {
-                    if (!_binaryEncodingIdByType.ContainsKey(type) && !_typeByBinaryEncodingId.ContainsKey(attr.NodeId))
+                    var attr = type.GetCustomAttribute<BinaryEncodingIdAttribute>(false);
+                    if (attr != null)
                     {
-                        _binaryEncodingIdByType.Add(type, attr.NodeId);
-                        _typeByBinaryEncodingId.Add(attr.NodeId, type);
+                        if (!_binaryEncodingIdByType.ContainsKey(type) && !_typeByBinaryEncodingId.ContainsKey(attr.NodeId))
+                        {
+                            _binaryEncodingIdByType.Add(type, attr.NodeId);
+                            _typeByBinaryEncodingId.Add(attr.NodeId, type);
+                        }
+                    }
+                    var attr2 = type.GetCustomAttribute<DataTypeIdAttribute>(false);
+                    if (attr2 != null)
+                    {
+                        if (!_dataTypeIdByType.ContainsKey(type) && !_typeByDataTypeId.ContainsKey(attr2.NodeId))
+                        {
+                            _dataTypeIdByType.Add(type, attr2.NodeId);
+                            _typeByDataTypeId.Add(attr2.NodeId, type);
+                        }
                     }
                 }
-                var attr2 = type.GetCustomAttribute<DataTypeIdAttribute>(false);
-                if (attr2 != null)
+                catch
                 {
-                    if (!_dataTypeIdByType.ContainsKey(type) && !_typeByDataTypeId.ContainsKey(attr2.NodeId))
-                    {
-                        _dataTypeIdByType.Add(type, attr2.NodeId);
-                        _typeByDataTypeId.Add(attr2.NodeId, type);
-                    }
+                    continue;
                 }
             }
         }


### PR DESCRIPTION
Related to this issue: https://github.com/convertersystems/opc-ua-client/issues/285

Add an additional try / catch so an exception in the parsing of one type does not cause the parsing of all types for an assembly to be aborted.

As described in the issue, currently a failure to parse one type causes the parsing to stop for all types in the assembly. This leads to types missing in the type library that are correctly defined and do not have parsing errors, making the debugging very confusing.

With this fix, only the types for which the parsing fails are missing, all other types are correctly added to the TypeLibrary.