### PR TITLE
Recreating and reconnecting ClientSessionChannel caused memory leaks. Implement IDisposable on all underlying objects.

### DIFF
--- a/UaClient/ServiceModel/Ua/Channels/BinaryDecoder.cs
+++ b/UaClient/ServiceModel/Ua/Channels/BinaryDecoder.cs
@@ -40,6 +40,11 @@ namespace Workstation.ServiceModel.Ua.Channels
             _reader = new BinaryReader(_stream, _encoding, keepStreamOpen);
         }
 
+        ~BinaryDecoder()
+        {
+            Dispose();
+        }
+
         public int Position
         {
             get { return (int)_stream.Position; }
@@ -49,6 +54,7 @@ namespace Workstation.ServiceModel.Ua.Channels
         public void Dispose()
         {
             _reader?.Dispose();
+            _stream?.Dispose();
         }
 
         public void PushNamespace(string namespaceUri)

--- a/UaClient/ServiceModel/Ua/Channels/BinaryEncoder.cs
+++ b/UaClient/ServiceModel/Ua/Channels/BinaryEncoder.cs
@@ -38,6 +38,11 @@ namespace Workstation.ServiceModel.Ua.Channels
             _writer = new BinaryWriter(_stream, _encoding, keepStreamOpen);
         }
 
+        ~BinaryEncoder()
+        {
+            Dispose();
+        }
+
         public int Position
         {
             get { return (int)_stream.Position; }
@@ -47,6 +52,7 @@ namespace Workstation.ServiceModel.Ua.Channels
         public void Dispose()
         {
             _writer?.Dispose();
+            _stream?.Dispose();
         }
 
         public void PushNamespace(string namespaceUri)

--- a/UaClient/ServiceModel/Ua/Channels/ClientSecureChannel.cs
+++ b/UaClient/ServiceModel/Ua/Channels/ClientSecureChannel.cs
@@ -36,8 +36,8 @@ namespace Workstation.ServiceModel.Ua.Channels
 
         private readonly CancellationTokenSource _channelCts;
         private readonly ILogger? _logger;
-        private SemaphoreSlim _sendingSemaphore = new SemaphoreSlim(1, 1);
-        private SemaphoreSlim _receivingSemaphore = new SemaphoreSlim(1, 1);
+        private readonly SemaphoreSlim _sendingSemaphore = new SemaphoreSlim(1, 1);
+        private readonly SemaphoreSlim _receivingSemaphore = new SemaphoreSlim(1, 1);
         private ActionBlock<ServiceOperation> _pendingRequests;
         private readonly ConcurrentDictionary<uint, ServiceOperation> _pendingCompletions;
 

--- a/UaClient/ServiceModel/Ua/Channels/ClientTransportChannel.cs
+++ b/UaClient/ServiceModel/Ua/Channels/ClientTransportChannel.cs
@@ -21,6 +21,7 @@ namespace Workstation.ServiceModel.Ua.Channels
 
         private readonly ILogger? _logger;
         private ITransportConnection? _connection;
+        private bool disposed = false;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="ClientTransportChannel"/> class.
@@ -43,6 +44,20 @@ namespace Workstation.ServiceModel.Ua.Channels
             LocalSendBufferSize = options?.LocalSendBufferSize ?? DefaultBufferSize;
             LocalMaxMessageSize = options?.LocalMaxMessageSize ?? DefaultMaxMessageSize;
             LocalMaxChunkCount = options?.LocalMaxChunkCount ?? DefaultMaxChunkCount;
+        }
+
+        protected override async void Dispose(bool disposing)
+        {
+            if (!disposed && disposing)
+            {
+                if (_connection != null && _connection is UaClientConnection)
+                {
+                    await ((UaClientConnection)_connection).DisposeAsync();
+                    _connection = null;
+                }
+
+            }
+            base.Dispose(disposing);
         }
 
         /// <summary>

--- a/UaClient/ServiceModel/Ua/Channels/CommunicationObject.cs
+++ b/UaClient/ServiceModel/Ua/Channels/CommunicationObject.cs
@@ -24,8 +24,8 @@ namespace Workstation.ServiceModel.Ua.Channels
         private bool _raisedClosing;
         private bool _raisedFaulted;
         private bool disposed = false;
-        private SemaphoreSlim _semaphore;
-        private Lazy<ConcurrentQueue<Exception>> _exceptions;
+        private readonly SemaphoreSlim _semaphore;
+        private readonly Lazy<ConcurrentQueue<Exception>> _exceptions;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="CommunicationObject"/> class.

--- a/UaClient/ServiceModel/Ua/Channels/CommunicationObject.cs
+++ b/UaClient/ServiceModel/Ua/Channels/CommunicationObject.cs
@@ -12,7 +12,7 @@ namespace Workstation.ServiceModel.Ua.Channels
     /// <summary>
     /// Provides a common base implementation for the basic state machine common to all communication-oriented objects in the system.
     /// </summary>
-    public abstract class CommunicationObject : ICommunicationObject
+    public abstract class CommunicationObject : ICommunicationObject, IDisposable
     {
         private readonly ILogger? _logger;
         private bool _aborted;
@@ -23,8 +23,9 @@ namespace Workstation.ServiceModel.Ua.Channels
         private bool _raisedClosed;
         private bool _raisedClosing;
         private bool _raisedFaulted;
-        private readonly SemaphoreSlim _semaphore;
-        private readonly Lazy<ConcurrentQueue<Exception>> _exceptions;
+        private bool disposed = false;
+        private SemaphoreSlim _semaphore;
+        private Lazy<ConcurrentQueue<Exception>> _exceptions;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="CommunicationObject"/> class.
@@ -35,6 +36,25 @@ namespace Workstation.ServiceModel.Ua.Channels
             _logger = loggerFactory?.CreateLogger(GetType());
             _semaphore = new SemaphoreSlim(1);
             _exceptions = new Lazy<ConcurrentQueue<Exception>>();
+        }
+
+        public void Dispose()
+        {
+            Dispose(true);
+            GC.SuppressFinalize(this);
+        }
+
+        protected virtual void Dispose(bool disposing)
+        {
+            if(!disposed && disposing)
+            {
+                _semaphore.Dispose();
+
+                while (_exceptions.Value.TryDequeue(out _)) { }
+                _exceptions = null; // Optional, if you want full release
+
+                disposed = true;
+            }
         }
 
         public event EventHandler? Closed;
@@ -433,7 +453,7 @@ namespace Workstation.ServiceModel.Ua.Channels
 
         protected void AddPendingException(Exception exception)
         {
-            _exceptions.Value.Enqueue(exception);
+            _exceptions?.Value.Enqueue(exception);
         }
 
         protected Exception? PeakFirstPendingException()

--- a/UaClient/ServiceModel/Ua/Channels/UaSecureConversation.cs
+++ b/UaClient/ServiceModel/Ua/Channels/UaSecureConversation.cs
@@ -402,7 +402,7 @@ namespace Workstation.ServiceModel.Ua.Channels
                     throw new ServiceResultException(StatusCodes.BadEncodingLimitsExceeded);
                 }
 
-                var stream = new MemoryStream(_sendBuffer, 0, (int)_options.ReceiveBufferSize, true, true);
+                using var stream = new MemoryStream(_sendBuffer, 0, (int)_options.ReceiveBufferSize, true, true);
                 using (var encoder = new BinaryEncoder(stream))
                 {
                     // header
@@ -541,7 +541,7 @@ namespace Workstation.ServiceModel.Ua.Channels
                     throw new ServiceResultException(StatusCodes.BadEncodingLimitsExceeded);
                 }
 
-                var stream = new MemoryStream(_sendBuffer, 0, (int)_options.ReceiveBufferSize, true, true);
+                using var stream = new MemoryStream(_sendBuffer, 0, (int)_options.ReceiveBufferSize, true, true);
                 using (var encoder = new BinaryEncoder(stream))
                 {
                     // header
@@ -705,7 +705,7 @@ namespace Workstation.ServiceModel.Ua.Channels
                     return (0, 0);
                 }
 
-                var stream = new MemoryStream(_receiveBuffer, 0, count, true, true);
+                using var stream = new MemoryStream(_receiveBuffer, 0, count, true, true);
                 using (var decoder = new BinaryDecoder(stream))
                 {
                     uint channelId;

--- a/UaClient/ServiceModel/Ua/Channels/UaTcpConnectionProvider.cs
+++ b/UaClient/ServiceModel/Ua/Channels/UaTcpConnectionProvider.cs
@@ -20,16 +20,24 @@ namespace Workstation.ServiceModel.Ua.Channels
         /// <inheritdoc />
         public async Task<ITransportConnection> ConnectAsync(string connectionString, CancellationToken token)
         {
-            var uri = new Uri(connectionString);
             var client = new TcpClient
             {
                 NoDelay = true
             };
+            try
+            {
+                var uri = new Uri(connectionString);
 
-            await client.ConnectAsync(uri.Host, uri.Port).TimeoutAfter(ConnectTimeout, token).ConfigureAwait(false);
+                await client.ConnectAsync(uri.Host, uri.Port).TimeoutAfter(ConnectTimeout, token).ConfigureAwait(false);
 
-            // The stream will own the client and takes care on disposing/closing it
-            return new UaClientConnection(client.GetStream(), uri);
+                // The stream will own the client and takes care on disposing/closing it
+                return new UaClientConnection(client.GetStream(), uri);
+            }
+            catch (Exception ex)
+            { 
+                client.Dispose();
+                throw ex;
+            }
         }
     }
 }

--- a/UaClient/ServiceModel/Ua/DiscoveryService.cs
+++ b/UaClient/ServiceModel/Ua/DiscoveryService.cs
@@ -30,7 +30,7 @@ namespace Workstation.ServiceModel.Ua
         {
             if (!disposed)
             {
-                semaphore?.Release();
+                semaphore?.Dispose();
                 innerChannel.Dispose();
                 disposed = true;
             }


### PR DESCRIPTION
Disposes DiscoveryService, semaphores, streams, tcpclients, empties queues.
After OpcClient has been faulted, then AbortASync should be called then Dispose on the object.