### PR TITLE
ServiceExtensions.TimeoutAfter cancellation fix

### DIFF
--- a/UaClient.UnitTests/UnitTests/ServiceExtensionsTests.cs
+++ b/UaClient.UnitTests/UnitTests/ServiceExtensionsTests.cs
@@ -209,5 +209,15 @@ namespace Workstation.UaClient.UnitTests
             await never.Invoking(t => t.TimeoutAfter(0))
                 .Should().ThrowAsync<TimeoutException>();
         }
+
+        [Fact]
+        public async Task ValueWithTimeoutAfterCanceled() 
+        {
+            var never = Never(10);
+            var token = new CancellationToken(true);
+
+            await never.Invoking(t => t.TimeoutAfter(0, token))
+                .Should().ThrowAsync<TaskCanceledException>();
+        }
     }
 }

--- a/UaClient.UnitTests/Workstation.UaClient.UnitTests.csproj
+++ b/UaClient.UnitTests/Workstation.UaClient.UnitTests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0-windows</TargetFramework>
+    <TargetFramework>net7.0-windows</TargetFramework>
     <AssemblyName>Workstation.UaClient.UnitTests</AssemblyName>
     <RootNamespace>Workstation.UaClient</RootNamespace>
     <Version>2.0.0</Version>

--- a/UaClient.UnitTests/Workstation.UaClient.UnitTests.csproj
+++ b/UaClient.UnitTests/Workstation.UaClient.UnitTests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net7.0-windows</TargetFramework>
+    <TargetFramework>net8.0-windows</TargetFramework>
     <AssemblyName>Workstation.UaClient.UnitTests</AssemblyName>
     <RootNamespace>Workstation.UaClient</RootNamespace>
     <Version>2.0.0</Version>

--- a/UaClient/ServiceModel/Ua/ServiceExtensions.cs
+++ b/UaClient/ServiceModel/Ua/ServiceExtensions.cs
@@ -166,14 +166,14 @@ namespace Workstation.ServiceModel.Ua
         public static async Task<TResult> TimeoutAfter<TResult>(this Task<TResult> task, TimeSpan timeout, CancellationToken token)
         {
             var t = await Task.WhenAny(task, Task.Delay(timeout, token)).ConfigureAwait(false);
-            if (task != t)
+            if (task != t) 
             {
-                if (!t.IsCanceled)
+                if (t.IsCanceled) 
                 {
-                    throw new TimeoutException($"Task timed out after {timeout}");
+                    throw new TaskCanceledException(t);
                 }
 
-                throw t.Exception!;
+                throw new TimeoutException($"Task timed out after {timeout}");
             }
 
             return await task.ConfigureAwait(false);


### PR DESCRIPTION
Fixes #289.

- Modifies the `ServiceExtensions.TimeoutAfter` overload that returns a `TResult` so that it correctly handles scenarios where the `Task.Delay` call is cancelled.
- Adds a unit test for calling `ServiceExtensions.TimeoutAfter` with a cancelled token.