### PR TITLE
Add missing ConfigureAwait calls

### DIFF
--- a/UaClient/ServiceModel/Ua/Channels/ClientSecureChannel.cs
+++ b/UaClient/ServiceModel/Ua/Channels/ClientSecureChannel.cs
@@ -332,7 +332,7 @@ namespace Workstation.ServiceModel.Ua.Channels
                 bodyStream.Position = 0;
 
                 var handle = request.RequestHeader!.RequestHandle;
-                await _conversation!.EncryptMessageAsync(bodyStream, MessageTypes.OPNF, handle, SendAsync, token);
+                await _conversation!.EncryptMessageAsync(bodyStream, MessageTypes.OPNF, handle, SendAsync, token).ConfigureAwait(false);
             }
         }
 
@@ -351,7 +351,7 @@ namespace Workstation.ServiceModel.Ua.Channels
                 bodyStream.Position = 0;
 
                 var handle = request.RequestHeader!.RequestHandle;
-                await _conversation!.EncryptMessageAsync(bodyStream, MessageTypes.CLOF, handle, SendAsync, token);
+                await _conversation!.EncryptMessageAsync(bodyStream, MessageTypes.CLOF, handle, SendAsync, token).ConfigureAwait(false);
             }
         }
 
@@ -370,7 +370,7 @@ namespace Workstation.ServiceModel.Ua.Channels
                 bodyStream.Position = 0;
 
                 var handle = request.RequestHeader!.RequestHandle;
-                await _conversation!.EncryptMessageAsync(bodyStream, MessageTypes.MSGF, handle, SendAsync, token);
+                await _conversation!.EncryptMessageAsync(bodyStream, MessageTypes.MSGF, handle, SendAsync, token).ConfigureAwait(false);
             }
         }
 

--- a/UaClient/ServiceModel/Ua/Channels/ClientSessionChannel.cs
+++ b/UaClient/ServiceModel/Ua/Channels/ClientSessionChannel.cs
@@ -312,10 +312,10 @@ namespace Workstation.ServiceModel.Ua.Channels
             // Ask for user identity. May show dialog.
             if (UserIdentityProvider != null)
             {
-                UserIdentity = await UserIdentityProvider(RemoteEndpoint);
+                UserIdentity = await UserIdentityProvider(RemoteEndpoint).ConfigureAwait(false);
             }
 
-            await base.OnOpeningAsync(token);
+            await base.OnOpeningAsync(token).ConfigureAwait(false);
         }
 
         /// <inheritdoc/>
@@ -338,7 +338,7 @@ namespace Workstation.ServiceModel.Ua.Channels
 
                 if (CertificateStore != null)
                 {
-                    var tuple = await CertificateStore.GetLocalCertificateAsync(LocalDescription, _logger, token);
+                    var tuple = await CertificateStore.GetLocalCertificateAsync(LocalDescription, _logger, token).ConfigureAwait(false);
                     LocalCertificate = tuple.Certificate?.GetEncoded();
                     LocalPrivateKey = tuple.Key;
                 }

--- a/UaClient/ServiceModel/Ua/Channels/UaClientConnection.cs
+++ b/UaClient/ServiceModel/Ua/Channels/UaClientConnection.cs
@@ -44,7 +44,7 @@ namespace Workstation.ServiceModel.Ua.Channels
 #pragma warning restore CS1998
         {
 #if NETCOREAPP3_0_OR_GREATER
-            await Stream.DisposeAsync();
+            await Stream.DisposeAsync().ConfigureAwait(false);
 #else
             Stream.Dispose();
 #endif
@@ -138,7 +138,7 @@ namespace Workstation.ServiceModel.Ua.Channels
         /// <inheritdoc />
         public async Task SendAsync(byte[] buffer, int offset, int count, CancellationToken token)
         {
-            await Stream.WriteAsync(buffer, offset, count, token);
+            await Stream.WriteAsync(buffer, offset, count, token).ConfigureAwait(false);
         }
 
         /// <inheritdoc />

--- a/UaClient/ServiceModel/Ua/Channels/UaSecureConversation.cs
+++ b/UaClient/ServiceModel/Ua/Channels/UaSecureConversation.cs
@@ -184,7 +184,7 @@ namespace Workstation.ServiceModel.Ua.Channels
                 {
                     if (_certificateStore != null)
                     {
-                        var result = await _certificateStore.ValidateRemoteCertificateAsync(cert, _logger, token);
+                        var result = await _certificateStore.ValidateRemoteCertificateAsync(cert, _logger, token).ConfigureAwait(false);
                         if (!result)
                         {
                             throw new ServiceResultException(StatusCodes.BadSecurityChecksFailed, "Remote certificate is untrusted.");
@@ -217,7 +217,7 @@ namespace Workstation.ServiceModel.Ua.Channels
             {
                 if (_localCertificate == null && _certificateStore != null)
                 {
-                    var tuple = await _certificateStore.GetLocalCertificateAsync(_localDescription, _logger, token);
+                    var tuple = await _certificateStore.GetLocalCertificateAsync(_localDescription, _logger, token).ConfigureAwait(false);
                     _localCertificate = tuple.Certificate?.GetEncoded();
                     _localPrivateKey = tuple.Key;
                 }

--- a/UaClient/ServiceModel/Ua/DirectoryStore.cs
+++ b/UaClient/ServiceModel/Ua/DirectoryStore.cs
@@ -183,7 +183,7 @@ namespace Workstation.ServiceModel.Ua
                 RsaKeyPairGenerator kg = new RsaKeyPairGenerator();
                 kg.Init(new KeyGenerationParameters(_rng, 2048));
                 return kg.GenerateKeyPair();
-            });
+            }).ConfigureAwait(false);
 
             key = kp.Private as RsaPrivateCrtKeyParameters;
 

--- a/UaClient/ServiceModel/Ua/ServiceExtensions.cs
+++ b/UaClient/ServiceModel/Ua/ServiceExtensions.cs
@@ -49,7 +49,7 @@ namespace Workstation.ServiceModel.Ua
                         InputArguments = new Variant[] { subscriptionId }
                     }
                 }
-            });
+            }).ConfigureAwait(false);
 
             var result = response.Results?[0];
 
@@ -86,7 +86,7 @@ namespace Workstation.ServiceModel.Ua
                         InputArguments = new Variant[] { condition.EventId, comment } // ?? new LocalizedText(string.Empty) }
                     }
                 }
-            });
+            }).ConfigureAwait(false);
             
             var result = response.Results?[0];
 
@@ -123,7 +123,7 @@ namespace Workstation.ServiceModel.Ua
                         InputArguments = new Variant[] { condition.EventId, comment } // ?? new LocalizedText(string.Empty) }
                     }
                 }
-            });
+            }).ConfigureAwait(false);
 
             var result = response.Results?[0];
 

--- a/UaClient/ServiceModel/Ua/SubscriptionBase.cs
+++ b/UaClient/ServiceModel/Ua/SubscriptionBase.cs
@@ -239,7 +239,7 @@ namespace Workstation.ServiceModel.Ua
                 return StatusCodes.BadServerNotConnected;
             }
 
-            return await this.InnerChannel.ConditionRefreshAsync(this.SubscriptionId);
+            return await this.InnerChannel.ConditionRefreshAsync(this.SubscriptionId).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -260,7 +260,7 @@ namespace Workstation.ServiceModel.Ua
                 return StatusCodes.BadServerNotConnected;
             }
 
-            return await this.InnerChannel.AcknowledgeAsync(condition, comment);
+            return await this.InnerChannel.AcknowledgeAsync(condition, comment).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -281,7 +281,7 @@ namespace Workstation.ServiceModel.Ua
                 return StatusCodes.BadServerNotConnected;
             }
 
-            return await this.InnerChannel.ConfirmAsync(condition, comment);
+            return await this.InnerChannel.ConfirmAsync(condition, comment).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -509,7 +509,7 @@ namespace Workstation.ServiceModel.Ua
                     channel.Closing += handler;
                     if (channel.State == CommunicationState.Opened)
                     {
-                        await tcs.Task;
+                        await tcs.Task.ConfigureAwait(false);
                     }
                 }
                 finally
@@ -528,7 +528,7 @@ namespace Workstation.ServiceModel.Ua
         {
             while (!token.IsCancellationRequested)
             {
-                await this.whenSubscribed.Task;
+                await this.whenSubscribed.Task.ConfigureAwait(false);
 
                 this.progress.Report(CommunicationState.Opening);
 
@@ -540,7 +540,7 @@ namespace Workstation.ServiceModel.Ua
                     }
 
                     // get a channel.
-                    this.innerChannel = await this.application.GetChannelAsync(this.endpointUrl, token);
+                    this.innerChannel = await this.application.GetChannelAsync(this.endpointUrl, token).ConfigureAwait(false);
 
                     try
                     {
@@ -581,7 +581,7 @@ namespace Workstation.ServiceModel.Ua
                                         SubscriptionId = id,
                                         ItemsToCreate = requests_chunk,
                                     };
-                                    var itemsResponse = await this.innerChannel.CreateMonitoredItemsAsync(itemsRequest);
+                                    var itemsResponse = await this.innerChannel.CreateMonitoredItemsAsync(itemsRequest).ConfigureAwait(false);
 
                                     if (itemsResponse.Results is { } results)
                                     {
@@ -613,7 +613,7 @@ namespace Workstation.ServiceModel.Ua
                             {
                                 await Task.WhenAny(
                                     this.WhenChannelClosingAsync(this.innerChannel, token),
-                                    this.whenUnsubscribed.Task);
+                                    this.whenUnsubscribed.Task).ConfigureAwait(false);
                             }
                             catch
                             {
@@ -642,12 +642,12 @@ namespace Workstation.ServiceModel.Ua
                                 {
                                     SubscriptionIds = new uint[] { id }
                                 };
-                                await this.innerChannel.DeleteSubscriptionsAsync(deleteRequest);
+                                await this.innerChannel.DeleteSubscriptionsAsync(deleteRequest).ConfigureAwait(false);
                             }
                             catch (Exception ex)
                             {
                                 this.logger?.LogError($"Error deleting subscription. {ex.Message}");
-                                await Task.Delay(2000);
+                                await Task.Delay(2000).ConfigureAwait(false);
                             }
                         }
 
@@ -657,14 +657,14 @@ namespace Workstation.ServiceModel.Ua
                     {
                         this.logger?.LogError($"Error creating subscription. {ex.Message}");
                         this.progress.Report(CommunicationState.Faulted);
-                        await Task.Delay(2000);
+                        await Task.Delay(2000).ConfigureAwait(false);
                     }
                 }
                 catch (Exception ex)
                 {
                     this.logger?.LogTrace($"Error getting channel. {ex.Message}");
                     this.progress.Report(CommunicationState.Faulted);
-                    await Task.Delay(2000);
+                    await Task.Delay(2000).ConfigureAwait(false);
                 }
             }
         }


### PR DESCRIPTION
Various `await` statements did not explicitly specify `ConfigureAwait`. This PR adds `.ConfigureAwait(false)` to all `await` calls where no awaiter behaviour was specified.

The [Microsoft.VisualStudio.Threading.Analyzers](https://www.nuget.org/packages/Microsoft.VisualStudio.Threading.Analyzers) package was used to detect the `await` statements that did not explicitly configure the awaiter behaviour.